### PR TITLE
Doc-ja: update NR/Musical notation

### DIFF
--- a/Documentation/ja/notation.tely
+++ b/Documentation/ja/notation.tely
@@ -1,6 +1,7 @@
 \input texinfo-ja @c -*- coding: utf-8; mode: texinfo; documentlanguage: ja -*-
 @ignore
-    Translation of GIT committish: fabcd22c8f88ea9a87241597f1e48c0a9adbfc6e
+    Translation of GIT committish: eb38c33a95cbe6adf9f176dfbb794373ec062605
+
 
     When revising a translation, copy the HEAD committish of the
     version that you are working on.  See TRANSLATION for details.
@@ -19,9 +20,14 @@
 扱っている題材に慣れ親しんでいることを前提としています。
 @end macro
 
-@c `Notation Reference' was born 1999-10-11 with git commit 940dda0...
+@c `Notation Reference' was born 1998-08-14 with this commit:
+@c release: 1.0.2
+@c author: Han-Wen Nienhuys
+@c commit: a3a44f9f3c581b6824b3a65f9039656693e09bbf
+@c   file: Documentation/tex/refman.yo
+
 @macro copyrightDeclare
-Copyright @copyright{} 1999--2015 by 著作者一同
+Copyright @copyright{} 1998--2015 by 著作者一同
 @end macro
 
 

--- a/Documentation/ja/notation/changing-defaults.itely
+++ b/Documentation/ja/notation/changing-defaults.itely
@@ -10,7 +10,7 @@
 
 @c \version "2.19.22"
 
-@c Translators: Yoshiki Sawada
+@c Translators: Tomohiro Tatejima, Yoshiki Sawada
 @c Translation status: post-GDP
 
 @node デフォルトを変更する
@@ -203,8 +203,8 @@ Score コンテキストは、@code{\score @{@dots{}@}} や @code{\layout @{@dot
 
 @strong{@emph{MensuralStaff}}
 
-@code{Staff} と同じでが、@c
-定量形式の楽曲を譜刻するためにデザインされている点が異なります。
+@code{Staff} と同じですが、@c
+計量形式の楽曲を譜刻するためにデザインされている点が異なります。
 
 @node 下位コンテキスト - ボイス
 @unnumberedsubsubsec 下位コンテキスト - ボイス
@@ -2579,6 +2579,7 @@ property (modified with @code{\set}) was created.
 * 入力モード::
 * 向きと配置::
 * 距離と距離の単位::
+* 寸法::
 * 譜記号プロパティ::
 * スパナ::
 * オブジェクトの可視性::
@@ -2881,6 +2882,36 @@ Scheme 関数 @code{magstep} を使用することができます。@c
 記譜法リファレンス:
 @ref{Page layout},
 @ref{譜サイズを設定する}
+
+
+@c 2017-9-22 このノードのみ先に翻訳
+@c 第1章のxrefを正しく動作させるため。
+@node 寸法
+@subsection 寸法
+@translationof Dimensions
+
+@cindex dimensions (寸法)
+@cindex bounding box (バウンディング ボックス)
+
+グラフィカル オブジェクトの寸法 (大きさ) は、オブジェクトの@c
+バウンディング ボックスの左右端の位置、上下端の位置を指定します。@c
+これらはオブジェクトの参照ポイントからの距離で指定し、単位は譜スペースです。@c
+これらの位置は通常 2 つの Scheme ペアで表現します。@c
+例えば、テキスト マークアップ コマンド @code{\with-dimensions} は
+3 つの引数を取り、最初の 2 つが左右端の位置と上下端の位置を示す
+Scheme ペアです:
+
+@example
+\with-dimensions #'(-5 . 10) #'(-3 . 15) @var{arg}
+@end example
+
+これは @var{arg} のバウンディング ボックスの@c
+左端を -5, 右端を 10, 下端を -3, 上端を 15 に指定しています。@c
+全てオブジェクトの参照ポイントから、譜スペースの単位で計測されています。
+
+@seealso
+記譜法リファレンス:
+@ref{距離と距離の単位}
 
 
 @node 譜記号プロパティ

--- a/Documentation/ja/notation/editorial.itely
+++ b/Documentation/ja/notation/editorial.itely
@@ -1,6 +1,6 @@
 @c -*- coding: utf-8; mode: texinfo; documentlanguage: ja -*-
 @ignore
-    Translation of GIT committish: c1b0482f63f881bd3f67845e5f76a3e04675ef2a
+    Translation of GIT committish: eb38c33a95cbe6adf9f176dfbb794373ec062605
 
     When revising a translation, copy the HEAD committish of the
     version that you are working on.  For details, see the Contributors'
@@ -10,7 +10,7 @@
 @c \version "2.19.21"
 
 
-@c Translators: Yoshiki Sawada
+@c Translators: Tomohiro Tatejima, Yoshiki Sawada
 @c Translation status: post-GDP
 
 
@@ -56,62 +56,212 @@
 
 @funindex fontSize
 @funindex font-size
+@funindex magnification->font-size
 @funindex magstep
-@funindex \huge
-@funindex \large
+@funindex magnifyMusic
+@funindex teeny
+@funindex tiny
+@funindex small
+@funindex normalsize
+@funindex large
+@funindex huge
+@funindex \magnifyMusic
+@funindex \teeny
+@funindex \tiny
 @funindex \normalsize
 @funindex \small
-@funindex \tiny
-@funindex \teeny
-@funindex huge
-@funindex large
-@funindex normalsize
-@funindex small
-@funindex tiny
-@funindex teeny
+@funindex \large
+@funindex \huge
 
-記譜要素のフォント サイズを変更することができます。@c
-これは連桁やスラーなどの可変シンボルのサイズは変更しません。
+@warning{@*
+テキストのフォント サイズに関しては、@c
+@ref{フォントとフォント サイズを選択する}を参照してください。@*
+譜のサイズに関しては、@ref{譜サイズを設定する}を参照してください。@*
+合図音符に関しては、@ref{合図音符をフォーマットする}を参照してください。@*
+オッシア譜に関しては、@ref{オッシア譜}を参照してください。}
 
-@warning{テキストのフォント サイズを変更する方法については
-@ref{Selecting font and font size} を参照してください。}
+譜のサイズを変えずに記譜のサイズを変更するには、@code{\magnifyMusic}
+コマンドに拡大縮小の割合を指定します:
 
-@lilypond[verbatim,quote,relative=2]
-\huge
-c4.-> d8---3
-\large
-c4.-> d8---3
-\normalsize
-c4.-> d8---3
-\small
-c4.-> d8---3
-\tiny
-c4.-> d8---3
-\teeny
-c4.-> d8---3
+@c Grieg Piano Concerto (mvt.1 cadenza)
+@lilypond[verbatim,quote]
+\new Staff <<
+  \new Voice \relative {
+    \voiceOne
+    <e' e'>4 <f f'>8. <g g'>16 <f f'>8 <e e'>4 r8
+  }
+  \new Voice \relative {
+    \voiceTwo
+    \magnifyMusic 0.63 {
+      \override Score.SpacingSpanner.spacing-increment = #(* 1.2 0.63)
+      r32 c'' a c a c a c r c a c a c a c
+      r c a c a c a c a c a c a c a c
+    }
+  }
+>>
 @end lilypond
 
-内部的には、これは @code{fontSize} プロパティを設定します。@c
-この設定により @code{font-size} プロパティが@c
-すべてのレイアウト オブジェクトにセットされます。@c
-@code{font-size} の値は、カレントの譜の高さでの標準フォント サイズからの@c
-相対値を表している数字です。@c
-1 段階上がる毎にフォント サイズは約 12% 増加します。@c
-6 段階でちょうど 2 倍になります。@c
-Scheme 関数 @code{magstep} は @code{font-size} 数をスケーリング ファクタに@c
-変換します。@c
-@code{font-size} プロパティを直接設定することも可能です。@c
-そうした場合、特定のレイアウト オブジェクトだけが影響を受けます。
+上の例にある @code{\override} は、不具合の一時的な回避措置です。@c
+このセクションの最後にある@qq{既知の問題と警告}を参照してください。
 
-@lilypond[verbatim,quote,relative=2]
-\set fontSize = #3
-c4.-> d8---3
-\override NoteHead.font-size = #-4
-c4.-> d8---3
-\override Script.font-size = #2
-c4.-> d8---3
-\override Stem.font-size = #-5
-c4.-> d8---3
+通常のサイズの音符が小さい音符とマージされる際には、符幹や臨時記号が正しく@c
+揃うように、小さい音符のサイズを@c
+(@w{@samp{\once@tie{}\normalsize}} によって) リセットする必要があります:
+
+@c Chopin Prelude op.28 no.8
+@lilypond[verbatim,quote]
+\new Staff <<
+  \key fis \minor
+  \mergeDifferentlyDottedOn
+  \new Voice \relative {
+    \voiceOne
+    \magnifyMusic 0.63 {
+      \override Score.SpacingSpanner.spacing-increment = #(* 1.2 0.63)
+      \once \normalsize cis'32( cis' gis b a fis \once \normalsize d d'
+      \once \normalsize cis, cis' gis b a gis \once \normalsize fis fis'
+      \once \normalsize fis, fis' ais, cis b gis \once \normalsize eis eis'
+      \once \normalsize a, a' bis, d cis b \once \normalsize gis gis')
+    }
+  }
+  \new Voice \relative {
+    \voiceTwo
+    cis'8. d16 cis8. fis16 fis8. eis16 a8. gis16
+  }
+>>
+@end lilypond
+
+@code{\magnifyMusic} コマンドは合図音符、装飾音符、オッシア譜を作るための@c
+ものとしては想定されていません -- これらには、より適切な作成方法があります。@c
+代わりに、このコマンドは以下のような場合に適しています:
+単一の譜にある、単一の楽器について、記譜サイズが変化し、@c
+しかし装飾音符を用いるのは適切ではない場合 -- 例えばカデンツァのような@c
+パッセージや上の例にあるような場合です。
+@code{\magnifyMusic} の値を 0.63 にセットすることで、@code{CueVoice} と同じ@c
+大きさになります。
+
+@warning{@code{@bs{}magnifyMusic} コマンドは譜のサイズを変更する時にも@c
+使うべきでは@i{ありません。}@ref{譜サイズを設定する}を参照してください。}
+
+
+@subsubsubheading 個々のレイアウト オブジェクトのサイズを変更する
+
+個々のレイアウト オブジェクトは @code{\tweak} や @code{\override} コマンドを@c
+使って、@code{font-size} プロパティを調整することでサイズを変更できます:
+
+@c KEEP LY
+@lilypond[quote,verbatim]
+\relative {
+  % 符頭のサイズを変更します
+  <f' \tweak font-size -4 b e>-5
+  % 運指記号のサイズを変更します
+  bes-\tweak font-size 0 -3
+  % 臨時記号のサイズを変更します
+  \once \override Accidental.font-size = -4 bes!-^
+  % アーティキュレーションのサイズを変更します
+  \once \override Script.font-size = 4 bes!-^
+}
+@end lilypond
+
+それぞれのレイアウト オブジェクトの @code{font-size} のデフォルト値は、@c
+内部リファレンスにリストアップされています。@code{font-size} プロパティは@c
+@code{font-interface} をサポートしているレイアウト オブジェクトにのみ@c
+設定できます。@code{font-size} がオブジェクトの @q{Standard@tie{}settings} に@c
+存在していない場合は、デフォルト値は 0 です。@c
+@rinternals{All layout objects} を参照してください。
+
+
+@subsubsubheading @code{fontSize} プロパティを理解する
+
+@code{fontSize} コンテキスト プロパティは、コンテキストに属する@c
+グリフ ベースの (訳注: フォントの文字として定義されている、詳しくは後述)
+記譜要素全ての相対サイズを調整します:
+
+@lilypond[verbatim,quote]
+\relative {
+  \time 3/4
+  d''4---5 c8( b a g) |
+  \set fontSize = -6
+  e'4-- c!8-4( b a g) |
+  \set fontSize = 0
+  fis4---3 e8( d) fis4 |
+  g2.
+}
+@end lilypond
+
+@code{fontSize} の値は、現在の譜の高さに応じた通常のサイズからの@c
+相対値を示しています。デフォルトの @code{fontSize} は 0 です。@c
+@code{fontSize} に 6 を加えることで大きさが 2 倍になり、@c
+6 を減じることで半分になります。1 が約 12% の増減になります。
+
+@code{font-size} プロパティの対数的な単位は常に直観的とは限りません。@c
+Scheme 関数 @code{magnification->font-size} はこれに対応する便利な関数です。@c
+例えば、記譜の大きさをデフォルトの 75% にしたい場合は、以下のようにします:
+
+@example
+\set fontSize = #(magnification->font-size 0.75)
+@end example
+
+Scheme 関数 @code{magstep} は逆のことをします: @code{font-size} の値を@c
+拡大縮小率に変換します。
+
+@code{fontSize} プロパティはグリフとして描かれている記譜要素のみに作用します
+-- 例えば、符頭、臨時記号、文字などです。譜のサイズそのものや、@c
+符幹、連桁のサイズ、水平方向のスペースなどは変化しません。@c
+(譜のサイズを変更せずに) 符幹、連桁のサイズや、水平方向のスペースを@c
+変更するには、上記の @code{\magnifyMusic} を使用してください。@c
+譜のサイズを含めて、全てのサイズを変更する場合は、@c
+@ref{譜サイズを設定する}を参照してください。
+
+@code{fontSize} @i{コンテキスト プロパティ} が設定されると、@c
+個々のレイアウト オブジェクトのグリフが出力される前に、@c
+@code{fontSize} の値と、@c
+@code{font-size} @i{グラフィカル オブジェクト プロパティ}の値が@c
+足し合わされます。これは、@code{fontSize} が既に設定されていて、@c
+個々の @code{font-size} プロパティを更に設定する場合に混乱するかもしれません:
+
+@c KEEP LY
+@lilypond[verbatim,quote,fragment]
+% NoteHead のデフォルトの font-size は 0 です
+% Fingering のデフォルトの font-size は -5 です
+c''4-3
+
+\set fontSize = -3
+% NoteHead のフォント サイズの最終的な値は -3 になります
+% Fingering のフォント サイズの最終的な値は -8 になります
+c''4-3
+
+\override Fingering.font-size = 0
+% Fingering のフォント サイズの最終的な値は -3 になります
+c''4-3
+@end lilypond
+
+以下のような短縮記法コマンドも存在します:
+
+@multitable @columnfractions .2 .4 .4
+@item @b{コマンド} @tab @b{同等なコマンド} @tab @b{相対サイズ}
+@item @code{\teeny}      @tab @code{\set fontSize = -3} @tab 71%
+@item @code{\tiny}       @tab @code{\set fontSize = -2} @tab 79%
+@item @code{\small}      @tab @code{\set fontSize = -1} @tab 89%
+@item @code{\normalsize} @tab @code{\set fontSize = 0} @tab 100%
+@item @code{\large}      @tab @code{\set fontSize = 1} @tab 112%
+@item @code{\huge}       @tab @code{\set fontSize = 2} @tab 126%
+@end multitable
+
+@lilypond[verbatim,quote]
+\relative c'' {
+  \teeny
+  c4.-> d8---3
+  \tiny
+  c4.-> d8---3
+  \small
+  c4.-> d8---3
+  \normalsize
+  c4.-> d8---3
+  \large
+  c4.-> d8---3
+  \huge
+  c4.-> d8---3
+}
 @end lilypond
 
 @cindex standard font size (notation) (標準フォント サイズ (記譜法))
@@ -121,18 +271,14 @@ c4.-> d8---3
 @funindex font-size
 
 フォント サイズの変更は、ひな形のサイズが望みのサイズに最も近くなるよう
-(一定の割合で) 増減することによって、達成されます@c
-標準フォント サイズ (@w{@code{font-size = #0}} のフォント サイズ) は@c
+(一定の割合で) 増減することによって、達成されます。@c
+標準フォント サイズ (@w{@code{font-size = 0}} のフォント サイズ) は@c
 標準の譜の高さに基づきます。@c
 20pt の譜では、11pt のフォントが選択されます。
 
-@code{font-size} プロパティはフォントを使用するレイアウト オブジェクトだけに@c
-セットすることができます@c
-そのようなオブジェクトは @code{font-interface} レイアウト インタフェイスを@c
-サポートします。
-
 
 @predefined
+@code{\magnifyMusic},
 @code{\teeny},
 @code{\tiny},
 @code{\small},
@@ -142,12 +288,43 @@ c4.-> d8---3
 @endpredefined
 
 @seealso
+記譜法リファレンス:
+@ref{Selecting font and font size},
+@ref{Setting the staff size},
+@ref{Formatting cue notes},
+@ref{Ossia staves}
+
+インストールされているファイル:
+@file{ly/music-functions-init.ly},
+@file{ly/property-init.ly}
+
 コード断片集:
 @rlsr{Editorial annotations}
 
 内部リファレンス:
 @rinternals{font-interface}
 
+@c The two issues mentioned below:
+@c http://code.google.com/p/lilypond/issues/detail?id=3987
+@c http://code.google.com/p/lilypond/issues/detail?id=3990
+@knownissues
+@code{\magnifyMusic} を使用する際に、水平方向のスペースが不適切になる
+2 つの不具合があります。これを解決する方法が 1 つだけありますが、@c
+全ての場合にうまくいくとは限りません。次の例で、@var{mag} 変数を@c
+好きな値に置き換えてください。@c
+@code{\newSpacingSection} コマンドの片方や両方、あるいは
+@code{\override} や @code{\revert} コマンドを取り除いてみることができます:
+
+
+@example
+\magnifyMusic @var{mag} @{
+  \newSpacingSection
+  \override Score.SpacingSpanner.spacing-increment = #(* 1.2 @var{mag})
+  [@var{music}]
+  \newSpacingSection
+  \revert Score.SpacingSpanner.spacing-increment
+@}
+@end example
 
 @node 運指の指示
 @unnumberedsubsubsec 運指の指示
@@ -160,17 +337,11 @@ c4.-> d8---3
 
 運指の指示は @var{音符}-@var{数字} を用いることで挿入することができます:
 
-@lilypond[verbatim,quote,relative=2]
-c4-1 d-2 f-4 e-3
-@end lilypond
-
-指の変更のためにマークアップ テキストや文字列が使用されることもあります。
-
 @lilypond[verbatim,quote]
 \relative { c''4-1 d-2 f-4 e-3 }
 @end lilypond
 
-指の入れ替えのためにマークアップ テキストを使うこともできます。
+指の入れ替えのためにマークアップ テキストや文字列を使うこともできます。
 
 @lilypond[verbatim,quote]
 \relative {
@@ -237,18 +408,17 @@ c4-1 d-2 f-4 e-3
 @unnumberedsubsubsec 隠された音符
 @translationof Hidden notes
 
-@cindex hidden notes
-@cindex invisible notes
-@cindex transparent notes
-@cindex notes, hidden
-@cindex notes, invisible
-@cindex notes, transparent
+@cindex hidden notes (隠された音符)
+@cindex invisible notes (不可視の音符)
+@cindex transparent notes (透明な音符)
+@cindex notes, hidden (隠された音符)
+@cindex notes, invisible (不可視の音符)
+@cindex notes, transparent (透明な音符)
 
 @funindex \hideNotes
 @funindex \unHideNotes
 
-@c 未訳
-隠された (または不可視、透明の) 音符は、preparing theory や作曲の演習の際に@c
+隠された (または不可視、透明の) 音符は、音楽理論や作曲の演習の際に@c
 有用です。
 
 @lilypond[verbatim,quote]
@@ -346,12 +516,13 @@ X11 のために定義された色の全範囲にアクセスすることがで�
 
 @c KEEP LY
 @lilypond[verbatim,quote]
-\relative c'' {
-  \override Staff.StaffSymbol.color = #(x11-color 'SlateBlue2)
-  \set Staff.instrumentName = \markup {
-    \with-color #(x11-color 'navy) "Clarinet"
+\new Staff \with {
+  instrumentName = \markup {
+    \with-color #(x11-color 'red) "Clarinet"
+    }
   }
-
+  \relative c'' {
+  \override Staff.StaffSymbol.color = #(x11-color 'SlateBlue2)
   gis8 a
   \override Beam.color = #(x11-color "medium turquoise")
   gis a
@@ -375,12 +546,13 @@ Scheme 関数 @code{rgb-color} を用いることによって、@c
 厳密な RGB カラーを指定することができます。
 
 @lilypond[verbatim,quote]
+\new Staff \with {
+  instrumentName = \markup {
+    \with-color #(x11-color 'red) "Clarinet"
+    }
+  }
 \relative c'' {
   \override Staff.StaffSymbol.color = #(x11-color 'SlateBlue2)
-  \set Staff.instrumentName = \markup {
-    \with-color #(x11-color 'navy) "Clarinet"
-  }
-
   \override Stem.color = #(rgb-color 0 0 0)
   gis8 a
   \override Stem.color = #(rgb-color 1 1 1)
@@ -415,8 +587,9 @@ X11 カラーは必ずしも同様の名前を持つノーマル カラーと@c
 Web 向けでは、ノーマル カラーを使用することを推奨します
 (つまり、@code{blue}, @code{green}, @code{red})。
 
-和音の中にある音符には @code{\override} で色を付けることはできません。@c
-@code{\override} の代わりに @code{\tweak} を使用してください
+和音の中にある音符に別々に色を付けるのに @code{\override} を使うことは@c
+できません。代わりにそれぞれの音符の前に @code{\tweak} や、それと同等な@c
+@code{\single\override} を使用してください
 -- @ref{The tweak command} を参照してください。
 
 
@@ -424,9 +597,8 @@ Web 向けでは、ノーマル カラーを使用することを推奨します
 @unnumberedsubsubsec 括弧
 @translationof Parentheses
 
-@c 保留: ghost notes
-@cindex ghost notes (ゴースト音符)
-@cindex notes, ghost (ゴースト音符)
+@cindex ghost notes (ゴースト ノート)
+@cindex notes, ghost (ゴースト ノート)
 @cindex notes, parenthesized (括弧で囲まれた音符)
 @cindex parentheses (括弧)
 @cindex brackets (囲み)
@@ -509,6 +681,9 @@ Web 向けでは、ノーマル カラーを使用することを推奨します
 @lilypondfile[verbatim,quote,ragged-right,texidoc,doctitle]
 {default-direction-of-stems-on-the-center-line-of-the-staff.ly}
 
+@lilypondfile[verbatim,quote,ragged-right,texidoc,doctitle]
+{automatically-changing-the-stem-direction-of-the-middle-note-based-on-the-melody.ly}
+
 @seealso
 記譜法リファレンス:
 @ref{Direction and placement}
@@ -574,16 +749,12 @@ Web 向けでは、ノーマル カラーを使用することを推奨します
 後者はたいてい和音の中で @code{\tweak} のように使用され、@c
 個々の音符にテキストを付加します。
 
-通常、バルーン ヘルプのテキストは音符の間隔に影響を与えますが、@c
-影響を与えないよう変更することもできます:
+バルーン ヘルプのテキストは音符の間隔に影響を与えませんが、@c
+影響を与えるように変更することもできます:
 
-Balloon text normally influences note spacing, but this can be
-altered:
-
-@lilypond[verbatim,quote,relative=2]
+@lilypond[verbatim,quote]
 \new Voice \with { \consists "Balloon_engraver" }
-{
-  \balloonLengthOff
+\relative c'' {
   \balloonGrobText #'Stem #'(3 . 4) \markup { "I'm a Stem" }
   a8
   \balloonGrobText #'Rest #'(-4 . -4) \markup { "I'm a rest" }
@@ -681,10 +852,10 @@ altered:
 @translationof Analysis brackets
 
 @cindex brackets (囲み、角括弧)
-@cindex bracket, phrasing (プレージングの囲み)
-@cindex phrasing bracket (プレージングの囲み)
+@cindex bracket, phrasing (フレーズの囲み)
+@cindex phrasing bracket (フレーズの囲み)
 @cindex musicological analysis (音楽学的分析)
-@cindex analysis, musicologica (音楽学的分析)l
+@cindex analysis, musicological (音楽学的分析)
 @cindex note grouping bracket (音符グループ化囲み)
 @cindex horizontal bracket (水平の囲み)
 @cindex bracket, horizontal (水平の囲み)
@@ -709,7 +880,7 @@ altered:
 }
 @end lilypond
 
-Analysis brackets may be nested.
+分析の囲みはネストすることができます。
 
 @lilypond[verbatim,quote]
 \layout {
@@ -726,12 +897,19 @@ Analysis brackets may be nested.
 }
 @end lilypond
 
-@seealso
-コード断片集:
-@rlsr{Editorial annotations}
+@snippets
 
+@lilypondfile[verbatim,quote,ragged-right,texidoc,doctitle]
+{analysis-brackets-above-the-staff.ly}
+
+@lilypondfile[verbatim,quote,ragged-right,texidoc,doctitle]
+{analysis-brackets-with-labels.ly}
+
+@seealso
 内部リファレンス:
 @rinternals{Horizontal_bracket_engraver},
 @rinternals{HorizontalBracket},
 @rinternals{horizontal-bracket-interface},
+@rinternals{HorizontalBracketText},
+@rinternals{horizontal-bracket-text-interface},
 @rinternals{Staff}

--- a/Documentation/ja/notation/expressive.itely
+++ b/Documentation/ja/notation/expressive.itely
@@ -1,6 +1,6 @@
 @c -*- coding: utf-8; mode: texinfo; documentlanguage: ja -*-
 @ignore
-    Translation of GIT committish: fabcd22c8f88ea9a87241597f1e48c0a9adbfc6e
+    Translation of GIT committish: eb38c33a95cbe6adf9f176dfbb794373ec062605
 
     When revising a translation, copy the HEAD committish of the
     version that you are working on.  For details, see the Contributors'
@@ -10,7 +10,7 @@
 @c \version "2.19.21"
 
 
-@c Translators: Yoshiki Sawada
+@c Translators: Tomohiro Tatejima, Yoshiki Sawada
 @c Translation status: post-GDP
 
 
@@ -54,7 +54,7 @@
 @cindex ornamentation (装飾)
 @cindex scripts (スクリプト)
 @cindex ornaments (装飾)
-@cindex espressivo (表現的な)
+@cindex espressivo (エスプレッシーヴォ)
 @cindex fermata (フェルマータ)
 @cindex upbow (アップボー、上弓)
 @cindex downbow (ダウンボー、下弓)
@@ -63,8 +63,7 @@
 @cindex pedal marks, organ (オルガン ペダル記号)
 @cindex turn (ターン)
 @cindex open (オープン)
-@c 未訳
-@cindex stopped
+@cindex stopped (ストップ、ミュート)
 @c フラジョレット: 六孔の縦笛
 @cindex flageolet (フラジョレット)
 @cindex reverseturn (逆ターン)
@@ -75,11 +74,12 @@
 @cindex prallmordent (プラルモルデント)
 @cindex prall, up (アップ プラル)
 @cindex prall, down (ダウン プラル)
-@cindex thumb marking
+@cindex mordent, up (アップ モルデント)
+@cindex mordent, down (ダウン モルデント)
+@cindex thumb marking (親指記号)
 @cindex segno (セーニョ)
 @cindex coda (コーダ)
-@c 未訳
-@cindex varcoda
+@cindex varcoda (変格コーダ)
 
 @funindex \accent
 @funindex \marcato
@@ -163,13 +163,15 @@
 それに @notation{portato}。@c
 これらの出力は以下のように表示されます:
 
-@lilypond[verbatim,quote,relative=2]
-c4-^  c-+  c--  c-!
-c4->  c-.  c2-_
+@lilypond[verbatim,quote]
+\relative {
+  c''4-^ c-+ c-- c-!
+  c4-> c-. c2-_
+}
 @end lilypond
 
 アーティキュレーションのデフォルトの配置規則は@c
-ファイル @file{scm/@/script@/.scm} で定義されています。@c
+ファイル @file{scm/script.scm} で定義されています。@c
 アーティキュレーションと装飾は手動で譜の上または下に配置されることもあります
 -- @ref{Direction and placement} を参照してください。
 
@@ -213,13 +215,17 @@ R1\fermataMarkup
 @rglos{staccato},
 @rglos{portato}
 
+学習マニュアル:
+@rlearning{Placement of objects}
+
 記譜法リファレンス:
+@ref{Text scripts},
 @ref{Direction and placement},
 @ref{List of articulations},
 @ref{トリル}
 
 インストールされているファイル:
-@file{scm/@/script@/.scm}
+@file{scm/script.scm}
 
 コード断片集:
 @rlsrnamed{Expressive marks,発想記号}
@@ -276,7 +282,6 @@ R1\fermataMarkup
 }
 @end lilypond
 
-@c 保留
 @cindex hairpin (ヘアピン)
 @cindex crescendo (クレッシェンド)
 @cindex decrescendo (デクレッシェンド)
@@ -316,7 +321,8 @@ R1\fermataMarkup
 開始によってヘアピンが終了する場合、@c
 そのヘアピンは次の @code{\<} または @code{\>} が割り当てられた@c
 音符の中央で終了します。@c
-次のへアピンは、通常通りに音符の左端で始まる代わりに、右端から始まります。
+次のへアピンは、通常通りに音符の左端で始まる代わりに、右端から始まります。@c
+1 拍目で終わるヘアピンは、前の小節線のところで終了します。
 
 @lilypond[verbatim,quote]
 \relative {
@@ -324,7 +330,7 @@ R1\fermataMarkup
 }
 @end lilypond
 
-@code{\!} の代わりに絶対強弱記号で終了するヘアピも同じように譜刻されます。@c
+@code{\!} の代わりに絶対強弱記号で終了するヘアピンも同じように譜刻されます。@c
 しかしながら、絶対強弱記号の幅によってヘアピンの終了点は変わります。
 
 @lilypond[verbatim,quote]
@@ -346,7 +352,7 @@ R1\fermataMarkup
 }
 @end lilypond
 
-@cindex espressivo articulation (表現的なアーティキュレーション)
+@cindex espressivo articulation (エスプレッシーヴォ アーティキュレーション)
 
 @funindex \espressivo
 
@@ -458,17 +464,32 @@ R1\fermataMarkup
 
 @snippets
 
+@cindex hairpins at bar lines (小節線で終わるヘアピン)
+
 @lilypondfile[verbatim,quote,texidoc,doctitle]
 {setting-hairpin-behavior-at-bar-lines.ly}
 
 @lilypondfile[verbatim,quote,texidoc,doctitle]
 {setting-the-minimum-length-of-hairpins.ly}
 
+@lilypondfile[verbatim,quote,texidoc,doctitle]
+{moving-the-ends-of-hairpins.ly}
+
 @cindex al niente (アル ニエンテ)
 @cindex niente, al (アル ニエンテ)
 
 @lilypondfile[verbatim,quote,texidoc,doctitle]
 {printing-hairpins-using-al-niente-notation.ly}
+
+@cindex Ferneyhough hairpins (ファーニホウのヘアピン)
+@cindex hairpins, Ferneyhough (ファーニホウのヘアピン)
+@cindex flared hairpins (裾の広いヘアピン)
+@cindex hairpins, flared (裾の広いヘアピン)
+@cindex constante hairpins (広がらないヘアピン)
+@cindex hairpins, constante (広がらないヘアピン)
+
+@lilypondfile[verbatim,quote,texidoc,doctitle]
+{printing-hairpins-in-various-styles.ly}
 
 @lilypondfile[verbatim,quote,texidoc,doctitle]
 {vertically-aligned-dynamics-and-textscripts.ly}
@@ -492,7 +513,7 @@ R1\fermataMarkup
 記譜法リファレンス:
 @ref{Direction and placement},
 @ref{新たな強弱記号},
-@ref{What goes into the MIDI output?},
+@ref{Enhancing MIDI output},
 @ref{Controlling MIDI dynamics}
 
 コード断片集:
@@ -624,10 +645,10 @@ moltoF = \tweak DynamicText.self-alignment-X #LEFT
 記譜法リファレンス:
 @ref{Formatting text},
 @ref{Selecting font and font size},
-@ref{What goes into the MIDI output?},
+@ref{Enhancing MIDI output},
 @ref{Controlling MIDI dynamics}
 
-LilyPond の拡張:
+拡張:
 @rextend{Markup construction in Scheme}
 
 コード断片集:
@@ -638,7 +659,6 @@ LilyPond の拡張:
 @subsection 曲線の発想記号
 @translationof Expressive marks as curves
 
-@c 未訳
 このセクションでは曲線を持つさまざまな発想記号
 -- 通常のスラー、フレージング スラー、ブレス記号、Fall それに Doit --
 を作成する方法について説明します。
@@ -684,20 +704,28 @@ LilyPond の拡張:
 @cindex slur, phrasing (フレージング スラー)
 @cindex slurs, multiple (多重スラー)
 @cindex slurs, simultaneous (同時進行のスラー)
+@funindex \=
 
-同時進行または重なり合うスラーは許可されません。@c
-しかしながら、フレージング スラーはスラーと重なり合うことができます。@c
-これにより、2 つのスラーを同時に譜刻することができます。@c
-詳細は @ref{フレージング スラー} を参照してください。
+同時進行する、あるいは重なるスラーは特別な注意を必要とします。@c
+通常、外側のスラーはフレージングを表し、フレージング スラーは通常のスラーと@c
+重複します。@ref{フレージング スラー}を参照してください。@c
+一つの @code{Voice} に通常のスラーが複数必要な場合、スラーの前に
+@code{\=} と識別子 (シンボルか非負の整数) を入力することによって、@c
+対応するスラーの始点と終点にラベルを付ける必要があります。
+
+@lilypond[verbatim,quote]
+\fixed c' {
+  <c~ f\=1( g\=2( >2 <c e\=1) a\=2) >
+}
+@end lilypond
 
 @cindex slur style (スラーのスタイル)
-@cindex solid slur (実線のスラー)
-@cindex dotted slur (点線のスラー)
-@cindex dashed slur (破線のスラー)
-@cindex sytle, slur (スラーのスタイル)
 @cindex slur, solid (実線のスラー)
 @cindex slur, dotted (点線のスラー)
 @cindex slur, dashed (破線のスラー)
+@cindex solid slur (実線のスラー)
+@cindex dotted slur (点線のスラー)
+@cindex dashed slur (破線のスラー)
 @cindex style, slur (スラーのスタイル)
 @funindex \slurDashed
 @funindex \slurDotted
@@ -839,7 +867,9 @@ LilyPond の拡張:
 @cindex phrasing slurs, simultaneous (同時進行のフレージング スラー)
 @cindex phrasing slurs, multiple (多重フレージング スラー)
 
-同時進行あるいは重なり合うフレージング スラーは許可されません。
+同時進行あるいは重なり合うフレージング スラーは、@c
+通常のスラーと同様に @code{\=} を用いて入力する必要があります。@c
+@ref{スラー} を参照してください。
 
 @funindex \phrasingSlurDashed
 @funindex \phrasingSlurDotted
@@ -951,6 +981,11 @@ LilyPond の拡張:
 { c''2. \breathe d''4 }
 @end lilypond
 
+ブレス記号は他の発想記号と異なり、前の音符と関連したものではなく、独立した@c
+音楽イベントです。そのため、前の音符に付加する発想記号や、手動連桁を示す@c
+角括弧、スラーやフレージング スラーを示す括弧は @code{\breathe} の前に@c
+配置されなければなりません。
+
 ブレス記号は自動連桁を終わらせます。@c
 この振る舞いをオーバライドする方法は、@ref{手動連桁} を参照してください。
 
@@ -958,9 +993,8 @@ LilyPond の拡張:
 \relative { c''8 \breathe d e f g2 }
 @end lilypond
 
-@c 保留
 古代記譜法でのブレス記号の音楽指示子 --
-divisiones (ディビジョン: 区切り) がサポートされています。@c
+divisio (ディビジオー: 区切り記号) がサポートされています。@c
 詳細は @ref{Divisiones} を参照してください。
 
 
@@ -969,17 +1003,14 @@ divisiones (ディビジョン: 区切り) がサポートされています。@
 @lilypondfile[verbatim,quote,texidoc,doctitle]
 {changing-the-breath-mark-symbol.ly}
 
-@c 未訳
-@cindex tick mark
+@cindex tick mark (チェック マーク)
 
 @lilypondfile[verbatim,quote,texidoc,doctitle]
 {using-a-tick-as-the-breath-mark-symbol.ly}
 
-@c 未訳
-@cindex caesura
-@cindex railroad tracks
+@cindex caesura (カエスーラ)
+@cindex railroad tracks (線路記号、カエスーラ)
 
-@c 未訳
 @lilypondfile[verbatim,quote,texidoc,doctitle]
 {inserting-a-caesura.ly}
 
@@ -1141,7 +1172,7 @@ Fall あるいは Doit の向きはプラスあるいはマイナス (上ある�
 @rinternals{Glissando}
 
 @knownissues
-線の上にテキストを譜刻する (@notation{グリッサンド} など) ことは@c
+線の上にテキストを譜刻する (@notation{gliss.} など) ことは@c
 サポートされていません。
 
 
@@ -1224,7 +1255,7 @@ Fall あるいは Doit の向きはプラスあるいはマイナス (上ある�
 @code{\arpeggioArrowDown},
 @code{\arpeggioNormal},
 @code{\arpeggioBracket},
-@code{\arpeggioParenthesis}
+@code{\arpeggioParenthesis},
 @code{\arpeggioParenthesisDashed}
 @endpredefined
 
@@ -1264,7 +1295,8 @@ Fall あるいは Doit の向きはプラスあるいはマイナス (上ある�
 ある @code{PianoStaff} の中の同時点で譜を跨ぐアルペジオと跨がないアルペジオを@c
 混在させることはできません。
 
-譜を跨ぐアルペジオに括弧スタイルのアルペジオを適用することはできません。
+譜を跨ぐアルペジオに括弧スタイルのアルペジオを適用することは単純な方法では@c
+できません。@ref{譜を跨ぐ符幹}を参照してください。
 
 
 @node トリル
@@ -1348,7 +1380,6 @@ Fall あるいは Doit の向きはプラスあるいはマイナス (上ある�
 }
 @end lilypond
 
-@c 未訳
 @cindex pitched trill with forced accidental (ピッチを持つトリルに強制的に臨時記号を付ける)
 @cindex trill, pitched with forced accidental (ピッチを持つトリルに強制的に臨時記号を付ける)
 @cindex accidental, forced for pitched trill (ピッチを持つトリルに強制的に臨時記号を付ける)
@@ -1357,22 +1388,21 @@ Fall あるいは Doit の向きはプラスあるいはマイナス (上ある�
 手動で譜刻を指定する必要があります。@c
 最初の小節では、最初のピッチを持つトリルだけに臨時記号が譜刻されています。
 
-@lilypond[verbatim,quote,relative=2]
-\pitchedTrill
-eis4\startTrillSpan fis
-eis4\stopTrillSpan
-
-\pitchedTrill
-eis4\startTrillSpan fis
-eis4\stopTrillSpan
-
-\pitchedTrill
-eis4\startTrillSpan fis
-eis4\stopTrillSpan
-
-\pitchedTrill
-eis4\startTrillSpan fis!
-eis4\stopTrillSpan
+@lilypond[verbatim,quote]
+\relative {
+  \pitchedTrill
+  eis''4\startTrillSpan fis
+  eis4\stopTrillSpan
+  \pitchedTrill
+  eis4\startTrillSpan cis
+  eis4\stopTrillSpan
+  \pitchedTrill
+  eis4\startTrillSpan fis
+  eis4\stopTrillSpan
+  \pitchedTrill
+  eis4\startTrillSpan fis!
+  eis4\stopTrillSpan
+}
 @end lilypond
 
 @predefined

--- a/Documentation/ja/notation/input.itely
+++ b/Documentation/ja/notation/input.itely
@@ -10,7 +10,7 @@
 @c \version "2.19.22"
 
 
-@c Translators: Yoshiki Sawada
+@c Translators: Tomohiro Tatejima, Yoshiki Sawada
 @c Translation status: post-GDP
 
 
@@ -26,7 +26,7 @@ LilyPond の一般的な入出力の問題について扱います。
 * タイトルとヘッダ::
 * 入力ファイルに取り組む::
 * 出力を制御する::
-* MIDI 出力::
+* MIDI 出力を作り出す::
 * 音楽情報を抽出する::
 @end menu
 
@@ -2527,9 +2527,11 @@ Gonville フォント ファミリーでは、@c
 製作者の Web サイトを参照してください。
 
 
-@node MIDI 出力
-@section MIDI 出力
-@translationof MIDI output
+@c 2017/9/22 ノード名とその翻訳のみ変更
+@c 第1章のxrefを正しく動作させるため。
+@node MIDI 出力を作り出す
+@section MIDI 出力を作り出す
+@translationof Creating MIDI output
 
 @cindex Sound (サウンド)
 @cindex MIDI
@@ -2561,7 +2563,7 @@ MIDI 出力は譜毎に 1 つのチャンネルを割り当て、@c
 * MIDI での繰り返し::
 * MIDI での音の強弱を制御する::
 * MIDI での打楽器::
-* 奏法スクリプト::
+* MIDI 出力をより良くする::
 @end menu
 
 @node MIDI ファイルを作り出す
@@ -3185,44 +3187,73 @@ MIDI 最小/最大ボリューム プロパティが設定されていない場�
 一般の MIDI 標準はリム ショットを含まないため、@c
 代わりにサイドスティックを用います。
 
+@c 2017-9-22 このノードと、続く奏法スクリプトのノードのみ先に翻訳
+@c 第1章のxrefを正しく動作させるため。
+@c 元の奏法スクリプトのノードは移動（実質削除）しました。
+@node MIDI 出力をより良くする
+@subsection MIDI 出力をより良くする
+@translationof Enhancing MIDI output
+
+@menu
+* 奏法スクリプト::
+@end menu
+
+デフォルトの MIDI 出力は必要最低限のものですが、@c
+MIDI の楽器を指定したり、@code{\midi} ブロックのプロパティを設定したり、@c
+奏法 (@file{articulate}) スクリプトを用いたりすることで@c
+より良くすることができます。
+
+@cindex instrument names (楽器名)
+@cindex MIDI, instruments (MIDI での楽器)
+@cindex articulate script (奏法スクリプト)
+@cindex articulate.ly
+@funindex Staff.midiInstrument
+
+
 @node 奏法スクリプト
-@subsection 奏法スクリプト
+@unnumberedsubsubsec 奏法スクリプト
 @translationof The Articulate script
 
-奏法スクリプトを用いることにより、よりリアルな MIDI 出力を得ることができます。@c
-奏法スクリプトは、音符を適切な時間比率の音符とスキップで置き換えることにより、@c
-アーティキュレーション (スラー、スタッカート等) を考慮に入れようとします。@c
-さらに、トリルやターンを展開しようとし、@c
-さらにラレンタンドとアッチェレランドを考慮に入れようとします。
-
-奏法スクリプトを使うには、@c
-入力ファイルの先頭で以下をインクルードする必要があります。
+奏法スクリプトを使うには、入力ファイルの最初にこのような
+@code{\include} コマンドを追加します:
 
 @example
 \include "articulate.ly"
 @end example
 
-さらに、@code{\score} セクションで以下のようにします。
+このスクリプトは、アーティキュレーションやテンポ表示を反映させるために、@c
+MIDI 出力の音符を正しく@q{タイム スケール}します。@c
+しかし、譜刻された出力も MIDI 出力の結果と対応して変化してしまいます。
 
 @example
-\unfoldRepeats \articulate <<
-	all the rest of the score...
->>
+\score @{
+  \articulate <<
+    @var{@dots{} music @dots{}}
+  >>
+  \midi @{ @}
+@}
 @end example
 
-この方法で入力ファイルを変更すると、@c
-出力される楽譜の見た目は著しく変わってしまいますが、@c
-標準の @code{\midi} ブロックはより良い MIDI ファイルを作り出します。
+@code{\articulate} コマンドは、省略記号 (トリルやターンなど) を解釈できます。@c
+対応している記号の一覧は、スクリプト内に記載してあります。@c
+@file{ly/articulate.ly} を参照してください。
 
-奏法スクリプトを機能させるための必須事項ではありませんが、@c
-上記の例のように @code{\unfoldRepeats} コマンドを挿入することにより、@c
-@notation{トリル} などの短縮記譜の演奏が可能になります。
+@seealso
+学習マニュアル:
+@rlearning{その他の情報源}
 
-@knownissues
+記譜法リファレンス:
+@ref{楽譜レイアウト}
 
-@c 未訳
-Articulate shortens chords といくつかの音楽 (特にオルガン音楽) の演奏は@c
-うまくいかないことがあります。
+インストールされているファイル:
+@file{ly/articulate.ly}
+
+@warning{奏法スクリプトは和音の長さを短くすることがあります。@c
+これはオルガン音楽などには適さないかもしれません。@c
+また、アーティキュレーションが全く付いていない音符も長さが短くなります。@c
+@code{\articulate} 関数を使う場所を一部分に限定するか、@c
+奏法スクリプトに定義された変数を書き換えることによって、@c
+長さが短くなる挙動を抑えることができます。}
 
 
 @node 音楽情報を抽出する

--- a/Documentation/ja/notation/pitches.itely
+++ b/Documentation/ja/notation/pitches.itely
@@ -1,14 +1,14 @@
 @c -*- coding: utf-8; mode: texinfo; documentlanguage: ja -*-
 @ignore
-    Translation of GIT committish: fabcd22c8f88ea9a87241597f1e48c0a9adbfc6e
+    Translation of GIT committish: eb38c33a95cbe6adf9f176dfbb794373ec062605
 
     When revising a translation, copy the HEAD committish of the
     version that you are working on.  See TRANSLATION for details.
 @end ignore
 
-@c \version "2.19.22"
+@c \version "2.19.53"
 
-@c Translators: Yoshiki Sawada
+@c Translators: Tomohiro Tatejima, Yoshiki Sawada
 @c Translation status: post-GDP
 
 
@@ -84,13 +84,37 @@
 @lilypond[verbatim,quote]
 {
   \clef treble
-  c'4 c'' e' g
-  d''4 d' d c
+  c'4 e' g' c''
+  c'4 g b c'
   \clef bass
-  c,4 c,, e, g
-  d,,4 d, d c
+  c,4 e, g, c
+  c,4 g,, b,, c,
 }
 @end lilypond
+
+@funindex \fixed
+共通して何度も用いられるオクターブ記号は、@code{\fixed} の後に基準ピッチを@c
+入力し、その後の音楽を入力することで 1 度だけで済みます。
+@code{\fixed} の中にあるピッチは、基準ピッチよりもオクターブ上か下にある場合@c
+にのみ @code{'} か@tie{}@code{,} の記号が必要です。
+
+@lilypond[verbatim,quote]
+{
+  \fixed c' {
+    \clef treble
+    c4 e g c'
+    c4 g, b, c
+  }
+  \clef bass
+  \fixed c, {
+    c4 e g c'
+    c4 g, b, c
+  }
+}
+@end lilypond
+
+@code{\fixed} の後に続く音楽表記内のピッチは、外側にあるいかなる
+@code{\relative} の影響も受けません。次で説明します。
 
 @seealso
 音楽用語集:
@@ -103,10 +127,6 @@
 @node 相対オクターブ入力
 @unnumberedsubsubsec 相対オクターブ入力
 @translationof Relative octave entry
-
-@c 本項目のみ先に翻訳 2015-12-31
-@c ドキュメント全体的に相対モードの開始ピッチ指定方法が変更されており、
-@c 従前のままの内容だと混乱をきたす可能性があるため。
 
 @cindex relative (相対)
 @cindex relative octave entry (相対オクターブ入力)
@@ -151,7 +171,7 @@
 @item
 最初の音符のピッチは @code{@var{startpitch}} と相対関係で決定されます。@c
 @var{startpitch} は絶対オクターブ モードで指定されます。@c
-どの選択肢がわかりやすですか？
+以下のどれがわかりやすいですか？
 
 @table @asis
 @item @code{c} のオクターブ
@@ -265,7 +285,7 @@
 @end lilypond
 
 上で説明したように、ピッチのオクターブは音符名のみを使って算出され、@c
-いかなる変更にも影響を受けません。@c
+いかなる変更 (訳注: シャープやフラット) にも影響を受けません。@c
 そのため、B の後の E ダブル シャープは B よりも上に配置され、@c
 B の後の F ダブル フラットは B よりも下に配置されます。@c
 言い換えると、重増 4 度は重減 5 度よりも小さい
@@ -279,6 +299,24 @@ B の後の F ダブル フラットは B よりも下に配置されます。@c
   b2 feses
 }
 @end lilypond
+
+状況が複雑であるときには、前の音符にかかわらず固定したピッチを指定するほうが@c
+有益かもしれません。これは @code{\resetRelativeOctave} によって行うことが@c
+できます。
+
+@lilypond[verbatim,quote]
+\relative {
+  <<
+    { c''2 d }
+    \\
+    { e,,2 f }
+  >>
+  \resetRelativeOctave c''
+  c2
+}
+@end lilypond
+
+@funindex \resetRelativeOctave
 
 
 @seealso
@@ -316,11 +354,11 @@ B の後の F ダブル フラットは B よりも下に配置されます。@c
 @c duplicated in Key signature and Accidentals
 @warning{LilyPond を始めたばかりのユーザは@c
 しばしば臨時記号と調号のことで混乱します。@c
-LilyPond では、音符名は未加工の入力です
--- 調号と音部記号がこの未加工の入力をどのように表示するかを決定します。@c
+LilyPond では、音符名はピッチを指定します
+-- 調号と音部記号がこれらのピッチをどのように表示するかを決定します。@c
 @code{c} のような変更を加えられていない音符は、調号や音部記号とは無関係に、@c
 @q{C ナチュラル} を意味します。@c
-更なる情報は、@rlearning{Accidentals and key signatures} を参照してください。}
+更なる情報は、@rlearning{ピッチと調号} を参照してください。}
 
 @cindex note names, Dutch (オランダ語での音符名)
 @cindex note names, default (デフォルトの音符名)
@@ -348,9 +386,9 @@ LilyPond では、音符名は未加工の入力です
 \relative c'' { ais1 aes aisis aeses }
 @end lilypond
 
-ナチュラルは臨時記号や調号の効果をキャンセルします。@c
-しかしながら、ナチュラルは接尾辞として音符名構文にエンコードされてはいません。@c
-そのため、ナチュラルのピッチは単に音符名で入力されます:
+ナチュラルのピッチは単に音符名を入力します。接尾辞は必要ありません。@c
+ナチュラル記号は、前の臨時記号や調号の効果をキャンセルするのに必要な場合に@c
+表示されます。
 
 @lilypond[verbatim,quote,fragment]
 \relative c'' { a4 aes a2 }
@@ -424,7 +462,7 @@ LilyPond では、音符名は未加工の入力です
 @rglos{quarter tone}
 
 学習マニュアル:
-@rlearning{Accidentals and key signatures}
+@rlearning{ピッチと調号}
 
 記譜法リファレンス:
 @ref{Automatic accidentals},
@@ -472,7 +510,7 @@ LilyPond の記号はいかなる標準にも準拠しません。
 利用可能な言語ファイルとそれらが定義している音符名を挙げます:
 
 @quotation
-@multitable {@code{nederlands}} {do re mi fa sol la sib si}
+@multitable {@code{nederlands}} {do re/re mi fa sol la sib si}
 @headitem 言語
   @tab 音符名
 @item @code{nederlands}
@@ -485,7 +523,9 @@ LilyPond の記号はいかなる標準にも準拠しません。
   @tab c d e f g a bf b
 @item @code{espanol} または @code{español}
   @tab do re mi fa sol la sib si
-@item @code{italiano} または @code{français}
+@item @code{français}
+  @tab do ré/re mi fa sol la sib si
+@item @code{italiano}
   @tab do re mi fa sol la sib si
 @item @code{norsk}
   @tab c d e f g a b h
@@ -503,33 +543,35 @@ LilyPond の記号はいかなる標準にも準拠しません。
 音符名に加えて、臨時記号の接尾辞も言語によって異なる場合があります:
 
 @quotation
-@multitable {@code{nederlands}} {-s/-sharp} {-ess/-es} {-ss/-x/-sharpsharp} {-essess/-eses}
-@headitem 言語
-  @tab シャープ @tab フラット @tab ダブル シャープ @tab ダブル フラット
+@multitable {@code{nederlands}} {-@code{s}/-@code{-sharp}} {-@code{f}/-@code{-flat}} {-@code{ss}/-@code{x}/-@code{-sharpsharp}} {-@code{ff}/-@code{-flatflat}}
+@headitem Language
+  @tab sharp @tab flat @tab double sharp @tab double flat
 @item @code{nederlands}
-  @tab -is @tab -es @tab -isis @tab -eses
+  @tab -@code{is} @tab -@code{es} @tab -@code{isis} @tab -@code{eses}
 @item @code{catalan}
-  @tab -d/-s @tab -b @tab -dd/-ss @tab -bb
+  @tab -@code{d}/-@code{s} @tab -@code{b} @tab -@code{dd}/-@code{ss} @tab -@code{bb}
 @item @code{deutsch}
-  @tab -is @tab -es @tab -isis @tab -eses
+  @tab -@code{is} @tab -@code{es} @tab -@code{isis} @tab -@code{eses}
 @item @code{english}
-  @tab -s/-sharp @tab -f/-flat @tab -ss/-x/-sharpsharp
-    @tab -ff/-flatflat
+  @tab -@code{s}/-@code{-sharp} @tab -@code{f}/-@code{-flat} @tab -@code{ss}/-@code{x}/-@code{-sharpsharp}
+    @tab -@code{ff}/-@code{-flatflat}
 @item @code{espanol} または @code{español}
-  @tab -s @tab -b @tab -ss/-x @tab -bb
-@item @code{italiano} または @code{français}
-  @tab -d @tab -b @tab -dd @tab -bb
+  @tab -@code{s} @tab -@code{b} @tab -@code{ss}/-@code{x} @tab -@code{bb}
+@item @code{français}
+  @tab -@code{d} @tab -@code{b} @tab -@code{dd}/-@code{x} @tab -@code{bb}
+@item @code{italiano}
+  @tab -@code{d} @tab -@code{b} @tab -@code{dd} @tab -@code{bb}
 @item @code{norsk}
-  @tab -iss/-is @tab -ess/-es @tab -ississ/-isis
-    @tab -essess/-eses
+  @tab -@code{iss}/-@code{is} @tab -@code{ess}/-@code{es} @tab -@code{ississ}/-@code{isis}
+    @tab -@code{essess}/-@code{eses}
 @item @code{portugues}
-  @tab -s @tab -b @tab -ss @tab -bb
+  @tab -@code{s} @tab -@code{b} @tab -@code{ss} @tab -@code{bb}
 @item @code{suomi}
-  @tab -is @tab -es @tab -isis @tab -eses
+  @tab -@code{is} @tab -@code{es} @tab -@code{isis} @tab -@code{eses}
 @item @code{svenska}
-  @tab -iss @tab -ess @tab -ississ @tab -essess
+  @tab -@code{iss} @tab -@code{ess} @tab -@code{ississ} @tab -@code{essess}
 @item @code{vlaams}
-  @tab -k @tab -b @tab -kk @tab -bb
+  @tab -@code{k} @tab -@code{b} @tab -@code{kk} @tab -@code{bb}
 @end multitable
 @end quotation
 
@@ -573,7 +615,9 @@ LilyPond ではどちらの形式も認められます。@c
   @tab -qs @tab -qf @tab -tqs @tab -tqf
 @item @code{espanol} または @code{español}
   @tab -cs @tab -cb @tab -tcs @tab -tcb
-@item @code{italiano} または @code{français}
+@item @code{français}
+  @tab -sd @tab -sb @tab -dsd @tab -bsb
+@item @code{italiano}
   @tab -sd @tab -sb @tab -dsd @tab -bsb
 @item @code{portugues}
   @tab -sqt @tab -bqt @tab -stqt @tab -btqt
@@ -654,9 +698,9 @@ LilyPond ではどちらの形式も認められます。@c
 これは前の音符と @code{@var{controlpitch}} との間の音程が
 4 度以内であるかどうかをチェックします
 (つまり、通常の相対モードでの算出方法と同じです)。@c
-このチェックが失敗した場合、警告が表示されますが、@c
-このチェックの前にある音符は変更されません。@c
-その後に続く音符は @code{@var{controlpitch}} から算出されます。
+このチェックが失敗した場合、警告が表示されます。@c
+このチェックの前にある音符は変更されませんが、@c
+その後に続く音符はオクターブが修正されます。
 
 @lilypond[verbatim,quote]
 \relative {
@@ -896,9 +940,13 @@ music = \relative { c'8. ees16( fis8. a16 b8.) gis16 f8. d16 }
 @end lilypond
 
 @knownissues
-@code{\retrograde} の中にある手動のタイは壊れて警告を発します。@c
-@ref{Automatic note splitting} を有効にすることによって@c
-自動的に生成させられるタイもあります。
+@code{\retrograde} は非常に単純なツールです。多くのイベントは交換ではなく@c
+@q{反転}するため、スパナの開始点にある調整や方向指示子は対応する終了点にも@c
+追加する必要があります。つまり、@code{^(} は @code{^)} によって終了しなければ@c
+ならないということです。全ての @code{\<} や @code{\cresc} は @code{\!} か
+@code{\endcr} で終わらなければならず、全ての @code{\>} や @code{\decr} は@c
+@code{\enddecr} で終わらなければなりません。効果が永続するような@c
+プロパティ変更のコマンドやオーバライドは予期しない結果を生み出すかもしれません。
 
 @seealso
 記譜法リファレンス:
@@ -990,9 +1038,6 @@ motif = \relative { c'8 d e f g a b c }
 @example
 \modalInversion @var{around-pitch} @var{to-pitch} @var{scale} @var{motif}
 @end example
-
-@var{motif} の音符は @var{scale} 内を @var{to-pitch} と @var{from-pitch}
-間の音程の度数の分だけシフトされます:
 
 @var{motif} の音符は @var{scale} 内を @var{around-pitch} から元の音符までと@c
 同じ度数の分だけ逆向きに進んだ位置に配置され、それからその結果は
@@ -1099,9 +1144,16 @@ motif = \relative { c'8. ees16 fis8. a16 b8. gis16 f8. d16 }
 
 @funindex \clef
 
-音部記号を変えることができます。@c
-以下のそれぞれの例の中にある音符はすべてミドル C です。@c
-例の中にある音部名をダブル クォートで囲むことができます (必須ではありません)。
+コマンドを明示しない場合、LilyPond のデフォルトの音部記号は高音部記号
+(ト音記号) です。
+
+@lilypond[verbatim,quote,fragment,ragged-right]
+c'2 c'
+@end lilypond
+
+しかし、音部記号は @code{\clef} コマンドと@c
+適切な音部記号の名前を用いることで変えることができます。@c
+以下のそれぞれの例の中にある音符はすべて@emph{ミドル C} です。@c
 
 @lilypond[verbatim,quote,fragment]
 \clef treble
@@ -1114,46 +1166,25 @@ c'2 c'
 c'2 c'
 @end lilypond
 
-他の音部記号もあります:
+指定することのできる全ての音部記号の名前は @ref{Clef styles} にあります。
 
-@c KEEP LY
-@lilypond[verbatim,quote,fragment]
-\clef french
-c'2 c'
-\clef soprano
-c'2 c'
-\clef mezzosoprano
-c'2 c'
-\clef baritone
-c'2 c'
+専門的な音部記号 -- 例えば@emph{古代の}音楽に用いられるもの --　は
+@ref{Mensural clefs} や @ref{Gregorian clefs} に説明してあります。@c
+タブ譜の音部記号が必要な音楽に関しては、
+@ref{Default tablatures} や @ref{Custom tablatures} に説明があります。
 
-\break
-
-\clef varbaritone
-c'2 c'
-\clef subbass
-c'2 c'
-\clef percussion
-c'2 c'
-
-\break
-
-\clef G   % treble と同義です
-c'2 c'
-\clef F   % bass と同義です
-c'2 c'
-\clef C   % alto と同義です
-c'2 c'
-@end lilypond
+@cindex Cue clefs (合図音符の音部記号)
+@cindex Clefs with cue notes (合図音符の音部記号)
+合図音符を用いる際の音部記号については、@ref{Formatting cue notes} の
+@code{\cueClef} や @code{\cueDuringWithClef} コマンドを参照してください。
 
 @cindex transposing clefs (音部を移調する)
 @cindex clef, transposing (音部を移調する)
 @cindex octave transposition (オクターブ移調)
-@c 未訳
-@cindex optional octave transposition
-@cindex octave transposition, optional
-@cindex choral tenor clef
-@cindex tenor clef, choral
+@cindex optional octave transposition (任意のオクターブ移調)
+@cindex octave transposition, optional (任意のオクターブ移調)
+@cindex choral tenor clef (合唱譜のテナー音部記号)
+@cindex tenor clef, choral (合唱譜のテナー音部記号)
 
 音部名に @code{_8} または @code{^8} を付け加えることによって、@c
 音部はそれぞれ 1 オクターブ下/上に移調され、@c
@@ -1188,12 +1219,63 @@ c'2 c'
 
 ピッチは数字の引数が括弧で囲まれていない場合と同じです。
 
-特殊な音部記号については @ref{Mensural clefs},
-@ref{Gregorian clefs}, @ref{Default tablatures}, それに
-@ref{Custom tablatures} で説明します。@c
-楽譜の中で合図音符を使用するときに音部記号を変更する場合は、@c
-@ref{Formatting cue notes} の @code{\cueClef} 関数と
-@code{\cueDuringWithClef} 関数を参照してください。
+デフォルトでは、改行のタイミングで音部記号の変更が行われる時には、@c
+次の行の音部記号の他に、前の行の最後に@emph{予告の}音部記号が表示されます。@c
+この@emph{予告の}音部記号は表示しないようにすることができます。
+
+@lilypond[verbatim,quote,fragment]
+\clef treble { c'2 c' } \break
+\clef bass { c'2 c' } \break
+\clef alto
+  \set Staff.explicitClefVisibility = #end-of-line-invisible
+  { c'2 c' } \break
+  \unset Staff.explicitClefVisibility
+\clef bass { c'2 c' } \break
+@end lilypond
+
+デフォルトでは、以前に表示された音部記号と同じ音部記号を @code{\clef}
+コマンドで指定しても、再表示はされず無視されます。この挙動は
+@code{\set Staff.forceClef = ##t} で変更することができます。
+
+@lilypond[verbatim,quote,fragment]
+  \clef treble
+  c'1
+  \clef treble
+  c'1
+  \set Staff.forceClef = ##t
+  c'1
+  \clef treble
+  c'1
+@end lilypond
+
+@noindent
+さらに正確に言うと、音部記号を表示するのは @code{\clef} コマンドそのものでは@c
+ありません。代わりに、このコマンドは @code{Clef_engraver} のプロパティを@c
+変更し、@code{Clef_engraver} はそれによって現在の譜に音部記号を表示するか@c
+どうかを決定します。@code{forceClef} プロパティはこの音部記号を表示するかの@c
+決定をその場で上書きします。
+
+手動で音部記号が変更された場合、変更後の音部記号は通常より小さく表示されます。@c
+この挙動を変更することができます。
+
+@lilypond[verbatim,quote,fragment]
+  \clef "treble"
+  c'1
+  \clef "bass"
+  c'1
+  \clef "treble"
+  c'1
+  \override Staff.Clef.full-size-change = ##t
+  \clef "bass"
+  c'1
+  \clef "treble"
+  c'1
+  \revert Staff.Clef.full-size-change
+  \clef "bass"
+  c'1
+  \clef "treble"
+  c'1
+@end lilypond
 
 @snippets
 
@@ -1207,6 +1289,9 @@ c'2 c'
 @ref{Default tablatures},
 @ref{Custom tablatures},
 @ref{Formatting cue notes}
+
+インストールされているファイル:
+@file{scm/parser-clef.scm}
 
 コード断片集:
 @rlsrnamed{Pitches,ピッチ}
@@ -1226,8 +1311,8 @@ c'2 c'
 
 @lilypond[fragment,quote,verbatim]
 \new Staff \with {
-  \override ClefModifier.color = #red
   \override Clef.color = #blue
+  \override ClefModifier.color = #red
 }
 
 \clef "treble_8" c'4
@@ -1249,7 +1334,7 @@ LilyPond では、音符名は未加工の入力です。@c
 調号と音部記号がこの未加工の入力をどのように表示するかを決定します。@c
 @code{c} のような変更を加えられていない音符は、調号や音部記号とは無関係に、@c
 @q{C ナチュラル} を意味します。@c
-更なる情報は、@rlearning{Accidentals and key signatures} を参照してください。}
+更なる情報は、@rlearning{ピッチと調号} を参照してください。}
 
 調号は楽曲を演奏すべき調性を示します。@c
 調号は譜の先頭で変更記号 (フラットやシャープ) のセットによって示されます。@c
@@ -1309,8 +1394,8 @@ freygish = #`((0 . ,NATURAL) (1 . ,FLAT) (2 . ,NATURAL)
     (3 . ,NATURAL) (4 . ,NATURAL) (5 . ,FLAT) (6 . ,FLAT))
 
 \relative {
-  \key c\freygish c'4 des e f
-  \bar "||" \key d\freygish d es fis g
+  \key c \freygish c'4 des e f
+  \bar "||" \key d \freygish d es fis g
 }
 @end lilypond
 
@@ -1346,7 +1431,7 @@ freygish = #`((0 . ,NATURAL) (1 . ,FLAT) (2 . ,NATURAL)
 @rglos{scordatura}
 
 学習マニュアル:
-@rlearning{Accidentals and key signatures}
+@rlearning{ピッチと調号}
 
 コード断片集:
 @rlsrnamed{Pitches,ピッチ}
@@ -1395,6 +1480,12 @@ freygish = #`((0 . ,NATURAL) (1 . ,FLAT) (2 . ,NATURAL)
 
 @lilypondfile[verbatim,quote,texidoc,doctitle]
 {ottava-text.ly}
+
+@lilypondfile[verbatim,quote,texidoc,doctitle]
+{adding-an-ottava-marking-to-a-single-voice.ly}
+
+@lilypondfile[verbatim,quote,texidoc,doctitle]
+{modifying-the-ottava-spanner-slope.ly}
 
 @seealso
 音楽用語集:
@@ -1447,46 +1538,57 @@ freygish = #`((0 . ,NATURAL) (1 . ,FLAT) (2 . ,NATURAL)
 
 @lilypond[verbatim,quote]
 \new GrandStaff <<
-  \new Staff = "violin" {
-    \relative c'' {
-      \set Staff.instrumentName = #"Vln"
-      \set Staff.midiInstrument = #"violin"
-      % not strictly necessary, but a good reminder
-      \transposition c'
-
-      \key c \major
-      g4( c8) r c r c4
-    }
+  \new Staff = "violin" \with {
+    instrumentName = #"Vln"
+    midiInstrument = #"violin"
   }
-  \new Staff = "clarinet" {
-    \relative c'' {
-      \set Staff.instrumentName = \markup { Cl (B\flat) }
-      \set Staff.midiInstrument = #"clarinet"
-      \transposition bes
-
-      \key d \major
-      a4( d8) r d r d4
-    }
+  \relative c'' {
+    % not strictly necessary, but a good reminder
+    \transposition c'
+    \key c \major
+    g4( c8) r c r c4
+  }
+  \new Staff = "clarinet" \with {
+    instrumentName = \markup { Cl (B\flat) }
+    midiInstrument = #"clarinet"
+  }
+  \relative c'' {
+    \transposition bes
+    \key d \major
+    a4( d8) r d r d4
   }
 >>
 @end lilypond
 
 @code{\transposition} は楽曲の途中で変更されることもあります。@c
 例えば、クラリネット奏者は A のクラリネットから B-フラットのクラリネットに@c
-持ち替えることがあります。
+持ち替えなければならないことがあります。
 
-@lilypond[verbatim,quote,relative=2]
-\set Staff.instrumentName = #"Cl (A)"
-\key a \major
-\transposition a
-c d e f
-\textLengthOn
-<>^\markup { Switch to B\flat clarinet }
-R1
-
-\key bes \major
-\transposition bes
-c2 g
+@lilypond[verbatim,quote]
+flute = \relative c'' {
+  \key f \major
+  \cueDuring #"clarinet" #DOWN {
+    R1 _\markup\tiny "clarinet"
+    c4 f e d
+    R1 _\markup\tiny "clarinet"
+  }
+}
+clarinet = \relative c'' {
+  \key aes \major
+  \transposition a
+  aes4 bes c des
+  R1^\markup { muta in B\flat }
+  \key g \major
+  \transposition bes
+  d2 g,
+}
+\addQuote "clarinet" \clarinet
+<<
+  \new Staff \with { instrumentName = #"Flute" }
+    \flute
+  \new Staff \with { instrumentName = #"Cl (A)" }
+    \clarinet
+>>
 @end lilypond
 
 @seealso
@@ -1595,6 +1697,7 @@ musicB = {
 両方の譜で同じ臨時記号スタイルを使うのなら、@c
 この例の最後のブロックを以下で置き換えられます:
 
+@c KEEP LY
 @example
 \new PianoStaff @{
   <<
@@ -1826,11 +1929,9 @@ musicB = {
 @funindex modern-cautionary
 
 この規則は @code{modern} と似ていますが、@c
-忠告的臨時記号として @q{追加の} 臨時記号が譜刻されます
-(これは @code{default} では譜刻されません)。@c
-デフォルトでは、この臨時記号は括弧で囲まれて譜刻されますが、@c
-@code{AccidentalSuggestion} の @code{cautionary-style} プロパティを@c
-定義することによって小さなサイズで譜刻されることもあり得ます。
+忠告的臨時記号として @q{追加の} 臨時記号が (括弧付きで) 譜刻されます。@c
+これらの臨時記号は、@code{AccidentalCautionary} の @code{font-size}
+プロパティをオーバライドすることで異なったサイズで表示することができます。
 
 @lilypond[quote]
 musicA = {
@@ -2133,6 +2234,127 @@ musicB = {
 }
 @end lilypond
 
+@item choral
+
+@cindex accidental style, choral (choral 臨時記号スタイル)
+@cindex accidentals, choral (choral 臨時記号)
+@cindex choral accidental style (choral 臨時記号スタイル)
+@cindex choral accidentals (choral 臨時記号)
+
+@funindex choral
+
+このルールは @code{modern-voice} と @code{piano} の組み合わせです。@c
+これは自身のボイスのみを追う歌手にとって必要な全ての臨時記号を表示し、@c
+また @code{ChoirStaff} の全てのボイスを同時に追う読譜者のために追加の@c
+臨時記号も表示します。
+
+この臨時記号スタイルは @code{ChoirStaff} でデフォルトで適用されています。
+
+@lilypond[quote]
+musicA = {
+  <<
+    \relative {
+      cis''8 fis, bes4 <a cis>8 f bis4 |
+      cis2. <c, g'>4 |
+    }
+    \\
+    \relative {
+      ais'2 cis, |
+      fis8 b a4 cis2 |
+    }
+  >>
+}
+
+musicB = {
+  \clef bass
+  \new Voice {
+    \voiceTwo \relative {
+      <fis a cis>8[ <fis a cis>
+      \change Staff = up
+      cis' cis
+      \change Staff = down
+      <fis, a> <fis a>]
+      \showStaffSwitch
+      \change Staff = up
+      dis'4 |
+      \change Staff = down
+      <fis, a cis>4 gis <f a d>2 |
+    }
+  }
+}
+
+\new ChoirStaff {
+  <<
+    \context Staff = "up" {
+      \accidentalStyle choral
+      \musicA
+    }
+    \context Staff = "down" {
+      \musicB
+    }
+  >>
+}
+@end lilypond
+
+@item choral-cautionary
+
+@cindex accidentals, choral cautionary (choral-cautionary 臨時記号)
+@cindex cautionary accidentals, choral (choral-cautionary 臨時記号)
+@cindex choral cautionary accidentals (choral-cautionary 臨時記号)
+@cindex accidental style, choral cautionary (choral-cautionary 臨時記号スタイル)
+@cindex cautionary accidental style, choral (choral-cautionary 臨時記号スタイル)
+@cindex choral cautionary accidental style (choral-cautionary 臨時記号スタイル)
+
+@funindex choral-cautionary
+
+この規則は @code{choral} と同じですが、追加の臨時記号は忠告として譜刻されます。
+
+@lilypond[quote]
+musicA = {
+  <<
+    \relative {
+      cis''8 fis, bes4 <a cis>8 f bis4 |
+      cis2. <c, g'>4 |
+    }
+    \\
+    \relative {
+      ais'2 cis, |
+      fis8 b a4 cis2 |
+    }
+  >>
+}
+
+musicB = {
+  \clef bass
+  \new Voice {
+    \voiceTwo \relative {
+      <fis a cis>8[ <fis a cis>
+      \change Staff = up
+      cis' cis
+      \change Staff = down
+      <fis, a> <fis a>]
+      \showStaffSwitch
+      \change Staff = up
+      dis'4 |
+      \change Staff = down
+      <fis, a cis>4 gis <f a d>2 |
+    }
+  }
+}
+
+\new ChoirStaff {
+  <<
+    \context Staff = "up" {
+      \accidentalStyle choral-cautionary
+      \musicA
+    }
+    \context Staff = "down" {
+      \musicB
+    }
+  >>
+}
+@end lilypond
+
 @item neo-modern
 
 @cindex neo-modern accidental style (neo-modern 臨時記号スタイル)
@@ -2205,7 +2427,9 @@ musicB = {
 @funindex neo-modern-cautionary
 
 この規則は @code{neo-modern} と似ていますが、@c
-追加の臨時記号は忠告の臨時記号として譜刻されます。
+追加の臨時記号は忠告の臨時記号として (括弧付きで) 譜刻されます。@c
+これらの臨時記号は、@code{AccidentalCautionary} の @code{font-size}
+プロパティをオーバライドすることで異なったサイズで表示することができます。
 
 @lilypond[quote]
 musicA = {
@@ -2432,6 +2656,122 @@ musicB = {
 }
 @end lilypond
 
+@item dodecaphonic-no-repeat
+
+@cindex dodecaphonic accidental style (dodecaphonic 臨時記号スタイル)
+@cindex dodecaphonic style, neo-modern (neo-modern 12 音スタイル)
+
+@funindex dodecaphonic-no-repeat
+
+@code{dodecaphonic} と似て、通常@emph{全ての} 音符に臨時記号が譜刻されますが、@c
+同じ譜の中でピッチが直後に繰り返される場合には譜刻されません。
+
+@lilypond[quote]
+musicA = {
+  <<
+    \relative {
+      cis''8 fis, bes4 <a cis>8 f bis4 |
+      cis2. <c, g'>4 |
+    }
+    \\
+    \relative {
+      ais'2 cis, |
+      fis8 b a4 cis2 |
+    }
+  >>
+}
+
+musicB = {
+  \clef bass
+  \new Voice {
+    \voiceTwo \relative {
+      <fis a cis>8[ <fis a cis>
+      \change Staff = up
+      cis' cis
+      \change Staff = down
+      <fis, a> <fis a>]
+      \showStaffSwitch
+      \change Staff = up
+      dis'4 |
+      \change Staff = down
+      <fis, a cis>4 gis <f a d>2 |
+    }
+  }
+}
+
+\new PianoStaff {
+  <<
+    \context Staff = "up" {
+      \accidentalStyle dodecaphonic-no-repeat
+      \musicA
+    }
+    \context Staff = "down" {
+      \accidentalStyle dodecaphonic-no-repeat
+      \musicB
+    }
+  >>
+}
+@end lilypond
+
+
+@item dodecaphonic-first
+
+@cindex dodecaphonic accidental style (dodecaphonic 臨時記号スタイル)
+@cindex dodecaphonic style, neo-modern (neo-modern 12 音スタイル)
+
+@funindex dodecaphonic-first
+
+@code{dodecaphonic} と似て、通常@emph{全ての} 音符に臨時記号が譜刻されますが、@c
+小節内で最初に出現したものに限られます。オクターブが異なるものは新たに@c
+譜刻されますが、異なるボイスでも臨時記号の効果は持続します。
+
+@lilypond[quote]
+musicA = {
+  <<
+    \relative {
+      cis''8 fis, bes4 <a cis>8 f bis4 |
+      cis2. <c, g'>4 |
+    }
+    \\
+    \relative {
+      ais'2 cis, |
+      fis8 b a4 cis2 |
+    }
+  >>
+}
+
+musicB = {
+  \clef bass
+  \new Voice {
+    \voiceTwo \relative {
+      <fis a cis>8[ <fis a cis>
+      \change Staff = up
+      cis' cis
+      \change Staff = down
+      <fis, a> <fis a>]
+      \showStaffSwitch
+      \change Staff = up
+      dis'4 |
+      \change Staff = down
+      <fis, a cis>4 gis <f a d>2 |
+    }
+  }
+}
+
+\new PianoStaff {
+  <<
+    \context Staff = "up" {
+      \accidentalStyle dodecaphonic-first
+      \musicA
+    }
+    \context Staff = "down" {
+      \accidentalStyle dodecaphonic-first
+      \musicB
+    }
+  >>
+}
+@end lilypond
+
 @item teaching
 
 @cindex teaching accidental style (teaching 臨時記号スタイル)
@@ -2622,7 +2962,7 @@ musicB = {
 内部リファレンス:
 @rinternals{Accidental},
 @rinternals{Accidental_engraver},
-@rinternals{GrandStaff} and
+@rinternals{GrandStaff},
 @rinternals{PianoStaff},
 @rinternals{Staff},
 @rinternals{AccidentalSuggestion},
@@ -2766,7 +3106,7 @@ forget = #(define-music-function (music) (ly:music?) #{
 @menu
 * 特殊な符頭::
 * 演奏を容易にする記譜法の符頭::
-* シェイプ符頭::
+* シェイプ ノートの符頭::
 * 即興::
 @end menu
 
@@ -2839,7 +3179,7 @@ forget = #(define-music-function (music) (ly:music?) #{
 使用することができます。@c
 @notation{dead note} という用語はギタリストが一般的に使用します。
 
-また、和音の中でのみ使用できるダイアモンド形のための短縮記法があります:
+また、ダイアモンド形のための似たような短縮記法があります:
 
 @lilypond[verbatim,quote]
 \relative c'' {
@@ -2933,26 +3273,26 @@ forget = #(define-music-function (music) (ly:music?) #{
 @rinternals{note-head-interface}
 
 
-@node シェイプ符頭
-@unnumberedsubsubsec シェイプ符頭
+@node シェイプ ノートの符頭
+@unnumberedsubsubsec シェイプ ノートの符頭
 @translationof Shape note heads
 
-@cindex note heads, shape (シェイプ符頭)
+@cindex note heads, shape (シェイプ ノートの符頭)
 @cindex note heads, Aiken (Aiken の符頭)
-@cindex note heads, sacred harp (セイクリッド ハープの符頭)
+@cindex note heads, sacred harp (Sacred Harp の符頭)
 @cindex shape notes (シェイプ ノート)
-@cindex Aiken shape note heads (Aiken のシェイプ符頭)
-@cindex sacred harp note heads (セイクリッド ハープの符頭)
-@cindex note heads, Southern Harmony
-@cindex Southern Harmony note heads
-@cindex Funk shape note heads
-@cindex note heads, Funk
-@cindex note heads, Harmonica Sacra
-@cindex Harmonica Sacra note heads
-@cindex Christian Harmony note heads
-@cindex note heads, Christian Harmony
-@cindex Walker shape note heads
-@cindex note heads, Walker
+@cindex Aiken shape note heads (Aiken のシェイプ ノートの符頭)
+@cindex sacred harp note heads (Sacred Harp の符頭)
+@cindex note heads, Southern Harmony (Southern Harmony の符頭)
+@cindex Southern Harmony note heads (Southern Harmony の符頭)
+@cindex Funk shape note heads (Funk のシェイプ ノートの符頭)
+@cindex note heads, Funk (Funk の符頭)
+@cindex note heads, Harmonica Sacra (Harmonica Sacra の符頭)
+@cindex Harmonica Sacra note heads (Harmonica Sacra の符頭)
+@cindex Christian Harmony note heads (Christian Harmony の符頭)
+@cindex note heads, Christian Harmony (Christian Harmony の符頭)
+@cindex Walker shape note heads (Walker のシェイプ ノートの符頭)
+@cindex note heads, Walker (Walker の符頭)
 
 @funindex \aikenHeads
 @funindex \sacredHarpHeads
@@ -2963,7 +3303,7 @@ forget = #(define-music-function (music) (ly:music?) #{
 シェイプ ノート記譜法では、@c
 符頭の形状は音階の中での音符の位置付けに対応します。@c
 この表記は 19 世紀のアメリカの歌集で一般的なものです。@c
-シェイプ符頭はセイクリッド ハープ、Southern Harmony、@c
+シェイプ ノートの符頭は Sacred Harp、Harmony、@c
 Funk (Harmonica Sacra)、Walker、それに Aiken (Christian Harmony) スタイルで@c
 使用されます:
 

--- a/Documentation/ja/notation/repeats.itely
+++ b/Documentation/ja/notation/repeats.itely
@@ -1,6 +1,6 @@
 @c -*- coding: utf-8; mode: texinfo; documentlanguage: ja -*-
 @ignore
-    Translation of GIT committish: c1b0482f63f881bd3f67845e5f76a3e04675ef2a
+    Translation of GIT committish: eb38c33a95cbe6adf9f176dfbb794373ec062605
 
     When revising a translation, copy the HEAD committish of the
     version that you are working on.  For details, see the Contributors'
@@ -10,7 +10,7 @@
 @c \version "2.19.21"
 
 
-@c Translators: Yoshiki Sawada
+@c Translators: Tomohiro Tatejima, Yoshiki Sawada
 @c Translation status: post-GDP
 
 
@@ -30,7 +30,9 @@ LilyPond は以下の種類の繰り返しをサポートします:
 繰り返される音楽は描き出されませんが、繰り返しの小節線で囲まれます。@c
 繰り返しが楽曲の先頭にある場合、繰り返しの小節線は繰り返しの終端にのみ@c
 譜刻されます。@c
-繰り返し時に入れ替えて演奏される部分 (volte) は囲みの右側に譜刻されます。@c
+@c 注: 原文では複数形 volte が使われているが、
+@c 　　日本語話者には混乱をきたすと思われるため単数形 volta を使うことにした。
+繰り返し時に入れ替えて演奏される部分 (volta) は囲みの右側に譜刻されます。@c
 これは入れ替えがある繰り返しの標準的な記譜法です。
 
 @item unfold
@@ -69,16 +71,15 @@ LilyPond は以下の種類の繰り返しをサポートします:
 * 繰り返しを描き出す::
 @end menu
 
-@c 未訳
 @cindex volta
-@cindex prima volta
-@cindex seconda volta
-@cindex volta, prima
-@cindex volta, seconda
-@cindex repeat, normal
-@cindex normal repeat
-@cindex repeat with alternate endings
-@cindex alternate endings
+@cindex prima volta (1 つ目の volta)
+@cindex seconda volta (2 つ目の volta)
+@cindex volta, prima (1 つ目の volta)
+@cindex volta, seconda (2 つ目の volta)
+@cindex repeat, normal (通常の繰り返し)
+@cindex normal repeat (通常の繰り返し)
+@cindex repeat with alternate endings (入れ替え部分を持つ繰り返し)
+@cindex alternate endings (繰り返しの入れ替え部分)
 @funindex \repeat
 @funindex \alternative
 @funindex \partial
@@ -101,6 +102,18 @@ LilyPond は以下の種類の繰り返しをサポートします:
 @lilypond[verbatim,quote]
 \relative {
   \repeat volta 2 { c''4 d e f }
+  c2 d
+  \repeat volta 2 { d4 e f g }
+}
+@end lilypond
+
+繰り返しの@q{開始}記号は、デフォルトでは最初の小節には表示されません。@c
+しかし、最初の音符の前に @code{\bar ".|:"} を用いることで表示させることが@c
+できます。
+
+@lilypond[verbatim,fragment,quote]
+\relative {
+  \repeat volta 2 { \bar ".|:" c''4 d e f }
   c2 d
   \repeat volta 2 { d4 e f g }
 }
@@ -136,8 +149,8 @@ LilyPond は以下の種類の繰り返しをサポートします:
 }
 @end lilypond
 
-複数の入れ替え部分を 1 回ずつ演奏する繰り返しは以下のようになります:
-
+繰り返しが複数回あり、最後に入れ替え部分を演奏する繰り返しは@c
+以下のようになります:
 
 @lilypond[verbatim,quote]
 \relative {
@@ -150,7 +163,7 @@ LilyPond は以下の種類の繰り返しをサポートします:
 }
 @end lilypond
 
-繰り返し部分を複数回繰り返す場合は以下のようになります:
+繰り返しが複数回あり、入れ替えも 2 つ以上ある繰り返しは以下のようになります:
 
 @lilypond[verbatim,quote]
 \relative {
@@ -180,98 +193,72 @@ LilyPond は以下の種類の繰り返しをサポートします:
 @cindex repeat with pickup (ピックアップを持つ繰り返し)
 @cindex pickup in a repeat (繰り返しの中にあるピックアップ)
 @funindex \partial
+@cindex bar checks with repeats (小節チェックと繰り返し)
+@cindex repeats with bar checks (繰り返しと小節チェック)
 
-繰り返しが小節の途中から始まり、入れ替え部分が無い場合、@c
-風通は繰り返しの終わりも小節の途中になります。@c
-そのため、1 つ小節に 2 つの終わりが加えられます。@c
-そのような場合、繰り返し記号は本来の小節線とは異なります。@c
-繰り返し記号を譜刻する場所で @code{\partila} コマンドや小節チェックを@c
-使わないで下さい:
+入れ替えの無い繰り返しが小節の途中で始まる場合、通常は後の小節の対応する@c
+中間部分で終了します (開始部分と終了部分で 1 つの完全な小節が作られます)。@c
+このような場合、繰り返し記号は@q{本当の}小節線ではないため、@c
+小節チェックや @code{\partial} コマンドをそこに置くべきではありません:
 
-@c KEEP LY
-@lilypond[verbatim,quote]
-\relative {
-  % ここで \partial を使わないで下さい
-  c'4 e g  % ここで小節チェックを行わないで下さい
-  % ここで \partial を使わないで下さい
-  \repeat volta 4 {
-    e4 |
-    c2 e |
-    % ここで \partial を使わないで下さい
-    g4 g g  % ここで小節チェックを行わないで下さい
-  }
-  % ここで \partial を使わないで下さい
+@lilypond[verbatim,quote,relative=1]
+c'4 e g
+\repeat volta 4 {
+  e4 |
+  c2 e |
+  g4 g g
+}
   g4 |
   a2 a |
   g1 |
-}
 @end lilypond
 
-同様に、繰り返しが楽譜の先頭の部分小節から始まり、入れ替え部分を持たない場合、@c
-楽譜の先頭で @code{\partial} コマンドを配置する必要があることを除いて、@c
-上の例と同じ条件が適用されます:
+入れ替えの無い繰り返しが部分小節で始まる場合は、@c
+@code{\partial} コマンドが小節の最初に必要であることを除けば、@c
+同じ原則が適用されます:
 
-@c KEEP LY
-@lilypond[verbatim,quote]
-\relative {
-  \partial 4  % \partial が必要です
-  \repeat volta 4 {
-    e'4 |
-    c2 e |
-    % ここで \partial を使わないで下さい
-    g4 g g  % ここで小節チェックを行わないで下さい
-  }
-  % ここで \partial を使わないで下さい
+@lilypond[verbatim,quote,relative=1]
+\partial 4
+\repeat volta 4 {
+  e'4 |
+  c2 e |
+  g4 g g
+}
   g4 |
   a2 a |
   g1 |
-}
 @end lilypond
 
-完全な長さを持たない小節で始まる小節に入れ替え部分を付け加える場合、@c
-以下の場所で @code{Timing.measureLength} コンテキスト プロパティを@c
-手動で設定する必要があります:
+@cindex repeats, with ties (タイを持つ繰り返し)
+@cindex alternative endings, with ties (タイを持つ繰り返しの入れ替え部分)
+@cindex ties, in repeats (繰り返しの中にあるタイ)
+@cindex ties, alternative endings (タイと繰り返しの入れ替え部分)
+@funindex \repeatTie
 
-@itemize
-@item
-@code{\alternative} ブロック内の不完全な小節の開始点。@c
-通常、これは (たいていの場合は) 最後の入れ替え部分を除く、@c
-各入れ替え部分の最後の小節になります。
-
-@item
-最初の入れ替え部分を除く、各入れ替え部分の開始点。
-@end itemize
+タイを 2 つ目の終了部に追加することができます:
 
 @lilypond[verbatim,quote]
 \relative {
-  \partial 4
-  \repeat volta 2 { e'4 | c2 e | }
+  c''1
+  \repeat volta 2 { c4 d e f~ }
   \alternative {
-    {
-      f2 d |
-      \set Timing.measureLength = #(ly:make-moment 3/4)
-      g4 g g  % optional bar check is allowed here
-    }
-    {
-      \set Timing.measureLength = #(ly:make-moment 4/4)
-      a2 a |
-    }
+    { f2 d }
+    { f2\repeatTie f, }
   }
-  g1 |
 }
 @end lilypond
-
-@code{measureLength} プロパティについての説明は @ref{Time administration}
-にあります。
 
 @funindex \inStaffSegno
+@cindex repeats, with segno (セーニョを持つ繰り返し)
+@cindex segno, with repeats (繰り返しを持つセーニョ)
 
-@code{\inStaffSegno} コマンドを用いて、セーニョ記号を配置して
-@code{\repeat volta} コマンドと連携させることができます。@c
-差し替えの小節線記号は Score コンテキストの中でプロパティ @code{segnoType},
-@code{startRepeatSegnoType}, @code{endRepeatSegnoType} あるいは
-@code{doubleRepeatSegnoType} を必要に応じてオーバライドすることにより@c
-設定することができます。
+@code{\inStaffSegno} コマンドは、@code{\repeat volta} コマンドと一緒に@c
+用いられた際に、繰り返しの小節線とセーニョ記号を合体させた小節線を@c
+作り出します。どの繰り返し記号が使われるか (すなわち、開始記号か、終了記号か、@c
+両者を合わせた記号か) は、自動的に選択されます。対応する @qq{D.S.} 記号は@c
+手動で入力しなければいけないことに注意してください。
+
+繰り返しを使わない:
 
 @lilypond[verbatim,quote]
 \relative {
@@ -282,22 +269,67 @@ LilyPond は以下の種類の繰り返しをサポートします:
 }
 @end lilypond
 
-@cindex repeats, with ties (タイを持つ繰り返し)
-@cindex alternative endings, with ties (タイを持つ繰り返しの入れ替え部分)
-@cindex ties, in repeats (繰り返しの中にあるタイ)
-@cindex ties, alternative endings (繰り返しの入れ替え部分でのタイ)
-@funindex \repeatTie
-
-繰り返しの 2 回目の部分にタイを付け加えることもできます:
+繰り返しの始まりに:
 
 @lilypond[verbatim,quote]
 \relative {
-  c''1
-  \repeat volta 2 { c4 d e f~ }
-  \alternative {
-    { f2 d }
-    { f2\repeatTie f, }
+  e'1
+  \repeat volta 2 {
+    \inStaffSegno  % start repeat
+    f2 g a b
   }
+  c1_"D.S." \bar "|."
+}
+@end lilypond
+
+繰り返しの終わりに:
+
+@lilypond[verbatim,quote]
+\relative {
+  e'1
+  \repeat volta 2 {
+    f2 g a b
+    \inStaffSegno  % end repeat
+  }
+  f2 g a b
+  c1_"D.S." \bar "|."
+}
+@end lilypond
+
+2 つの繰り返しの間に:
+
+@lilypond[verbatim,quote]
+\relative {
+  e'1
+  \repeat volta 2 {
+    f2 g a b
+  }
+  \inStaffSegno  % double repeat
+  \repeat volta 2 {
+    f2 g a b
+  }
+  c1_"D.S." \bar "|."
+}
+@end lilypond
+
+他の小節線記号を用いる場合、 (Score コンテキストに) プロパティ
+@code{segnoType}, @code{startRepeatSegnoType}, @code{endRepeatSegnoType},
+@code{doubleRepeatSegnoType} を好みの値を設定します。小節線の種類は@c
+あらかじめ定義されているものか、前に @code{\defineBarLine} コマンドで定義@c
+されているものから選択する必要があります (@ref{小節線}を参照してください)。
+
+@lilypond[verbatim,quote]
+\defineBarLine ":|.S[" #'(":|." "S[" "")
+\defineBarLine "]" #'("]" "" "")
+\relative {
+  e'1
+  \repeat volta 2 {
+    f2 g a b
+    \once \set Score.endRepeatSegnoType = ":|.S["
+    \inStaffSegno
+  }
+  f2 g \bar "]" a b
+  c1_"D.S." \bar "|."
 }
 @end lilypond
 
@@ -328,6 +360,9 @@ LilyPond は以下の種類の繰り返しをサポートします:
 @ref{Modifying context plug-ins},
 @ref{Modifying ties and slurs},
 @ref{Time administration}
+
+インストールされているファイル:
+@file{ly/engraver-init.ly}
 
 コード断片集:
 @rlsr{Repeats}
@@ -421,7 +456,7 @@ LilyPond は以下の種類の繰り返しをサポートします:
 
 @table @code
 @item start-repeat
-@code{|:} 小節線を譜刻します。
+@code{.|:} 小節線を譜刻します。
 
 @lilypond[verbatim,quote]
 \relative {
@@ -446,7 +481,7 @@ LilyPond は以下の種類の繰り返しをサポートします:
 }
 @end lilypond
 
-@item (volta @var{number}) ... (volta #f)
+@item (volta @var{number}) @dots{} (volta #f)
 指定された番号を持つ新しい volta を作成します。@c
 Volta 囲みは明示的に終了させる必要があります。@c
 さもなければ、譜刻されません。
@@ -751,6 +786,26 @@ a'4 b c | a'4 b c
 @rinternals{Double_percent_repeat_engraver},
 @rinternals{Slash_repeat_engraver}
 
+@knownissues
+パーセント記号の繰り返しは、パーセント記号以外に何も含むことができません。@c
+特に、拍子の変更は繰り返されません。
+
+@lilypond[quote,verbatim,relative=2]
+\repeat percent 3 { \time 5/4 c2. 2 \time 4/4 2 2 }
+@end lilypond
+
+@noindent
+拍子の変更や @code{\partial} コマンドは、パーセント記号の繰り返しの@c
+@emph{外側に}ある並列部分で行われる必要があります (例えば、独立した@c
+タイミング トラック)。
+
+@lilypond[quote,verbatim,relative=2]
+<<
+  \repeat percent 3 { c2. 2 2 2 }
+  \repeat unfold 3 { \time 5/4 s4*5 \time 4/4 s1 }
+>>
+@end lilypond
+
 
 @node トレモロの繰り返し
 @unnumberedsubsubsec トレモロの繰り返し
@@ -802,7 +857,6 @@ a'4 b c | a'4 b c
 @end lilypond
 
 @cindex tremolo marks (トレモロ記号)
-@funindex tremoloFlags
 @funindex :
 
 音符の後に @code{:@var{N}} を付け加えることによって@c
@@ -810,7 +864,7 @@ a'4 b c | a'4 b c
 @code{@var{N}} は細部の演奏時間を表し、8 以上である必要があります。@c
 @code{@var{N}} が 8 である場合、音符の符幹に 1 本の連桁が付け加えられます。@c
 @code{@var{N}} が省略された場合、
-最後の値 (@code{tremoloFlags} に保存されています) が使用されます:
+最後の値が使用されます:
 
 @lilypond[quote,verbatim]
 \relative {

--- a/Documentation/ja/notation/rhythms.itely
+++ b/Documentation/ja/notation/rhythms.itely
@@ -1,6 +1,6 @@
 @c -*- coding: utf-8; mode: texinfo; documentlanguage: ja -*-
 @ignore
-    Translation of GIT committish: d5647c5fd1c38d4124d2374725b923f4901f3661
+    Translation of GIT committish: eb38c33a95cbe6adf9f176dfbb794373ec062605
 
     When revising a translation, copy the HEAD committish of the
     version that you are working on.  See TRANSLATION for details.
@@ -8,7 +8,7 @@
 
 @c \version "2.19.40"
 
-@c Translators: Yoshiki Sawada
+@c Translators: Tomohiro Tatejima, Yoshiki Sawada
 @c Translation status: post-GDP
 
 
@@ -101,6 +101,16 @@
 \relative { a' a a2 a a4 a a1 a }
 @end lilypond
 
+音楽の中で演奏時間のみを入力した場合、前の音符や和音のピッチを引き継ぎます。
+
+@lilypond[quote,verbatim]
+\relative {
+  \time 8/1
+  c'' \longa \breve 1 2
+  4 8 16 32 64 128 128
+}
+@end lilypond
+
 @cindex notes, dotted (付点音符)
 @cindex dotted notes (付点音符)
 @cindex notes, double-dotted (2 重付点音符)
@@ -188,10 +198,6 @@
 @node 連符
 @unnumberedsubsubsec 連符
 @translationof Tuplets
-
-@c 本項目のみ先に翻訳 2015-12-31
-@c 連符のコマンドが \times から \tuplet に変更されており、
-@c 従前のままの内容だと混乱をきたす可能性があるため。
 
 @cindex tuplets (連符)
 @cindex triplets (3 連符)
@@ -343,16 +349,18 @@ MIDI 出力での演奏時間を決定するために使用されます。@c
 以下の例では、最初の 3 つの音符で 2 拍ですが、連符囲みは譜刻されていません。
 
 @c KEEP LY
-@lilypond[quote,relative=2,verbatim]
-\time 2/4
-% 演奏時間を変更して 3 連符にします
-a4*2/3 gis a
-% 通常の演奏時間
-a4 a
-% 和音の演奏時間を 2 倍にします
-<a d>4*2
-% 演奏時間は 4 分音符ですが、見た目は 16 分音符です
-b16*4 c4
+@lilypond[quote,verbatim]
+\relative {
+  \time 2/4
+  % 演奏時間を変更して 3 連符にします
+  a'4*2/3 gis a
+  % 通常の演奏時間
+  a4 a
+  % 和音の演奏時間を 2 倍にします
+  <a d>4*2
+  % 演奏時間は 4 分音符ですが、見た目は 16 分音符です
+  b16*4 c4
+}
 @end lilypond
 
 空白休符の演奏時間も掛け算によって変更できます。@c
@@ -371,17 +379,19 @@ b16*4 c4
 ここで、音楽がどのように圧縮され、伸張されるかを示す例を挙げます:
 
 @c KEEP LY
-@lilypond[quote,relative=2,verbatim]
-\time 2/4
-% 通常の演奏時間
-<c a>4 c8 a
-% 2/3 を掛けます
-\scaleDurations 2/3 {
-  <c a f>4. c8 a f
-}
-% 2 を掛けます
-\scaleDurations 2/1 {
-  <c' a>4 c8 b
+@lilypond[quote,verbatim]
+\relative {
+  \time 2/4
+  % 通常の演奏時間
+  <c'' a>4 c8 a
+  % 2/3 を掛けます
+  \scaleDurations 2/3 {
+    <c a f>4. c8 a f
+  }
+  % 2 を掛けます
+  \scaleDurations 2/1 {
+    <c' a>4 c8 b
+  }
 }
 @end lilypond
 
@@ -396,6 +406,16 @@ b16*4 c4
 
 コード断片集:
 @rlsr{Rhythms}
+
+@knownissues
+小節内での位置の計算はその小節の音符に適用される全ての演奏時間の伸縮や、@c
+それより前の小節からの計算結果を考慮する必要があります。@c
+この計算は分数を用いて行われています。@c
+計算の途中で分子あるいは分母が 2^30 を超えると、プログラムの実行と譜刻は@c
+その時点でエラーを発生せずに止まります。
+(訳注: 内部的に、分子と分母をそれぞれ整数型として持つ分数型を@c
+用いているため、あまりに複雑な演奏時間の伸縮を行うと、計算の途中で分子や分母が@c
+2^30 を超えてしまい譜刻が途中で止まってしまうということです。)
 
 
 @node タイ
@@ -413,10 +433,19 @@ b16*4 c4
 @emph{フレージング スラー} と混同しないでください。@c
 タイは音符の演奏時間を伸ばす働きを持ち、音価を増やすドットに似ています。}
 
-タイはチルド記号 @code{~} を使って入力します:
+タイは、結ばれる 2 つの音符の 1 つ目にチルド記号 (@code{~}) を付加することで@c
+入力します。この記号は音符が次の音符とタイで結ばれるということを示し、@c
+次の音符は同じピッチでなければなりません。
 
-@lilypond[quote,verbatim,relative=2]
-a2 ~ 2
+@lilypond[quote,verbatim]
+{ a'2~ 4~ 16 r r8 }
+@end lilypond
+
+タイでは、演奏時間のみを入力することで@q{最後に明示されたピッチ}を用いることが@c
+できます:
+
+@lilypond[quote,verbatim]
+{ a'2~ 4~ 16 r r8 }
 @end lilypond
 
 タイは、音符が小節線をまたがる場合か、リズムを表すためにドットを@c
@@ -429,8 +458,8 @@ a2 ~ 2
 @c KEEP LY
 @lilypond[verbatim,quote]
 \relative {
-  r8 c'8 ~ 2 r4 |
-  r8^"こうすべきではありません" c2 ~ 8 r4
+  r8 c'4.~ 4 r4 |
+  r8^"こうすべきではありません" c2~ 8 r4
 }
 @end lilypond
 
@@ -446,9 +475,12 @@ a2 ~ 2
 一致する符頭が無い場合、タイは作成されません。@c
 和音の内部にタイを置くことによって、和音の一部だけをタイで結ぶことができます。
 
-@lilypond[quote,verbatim,relative=1]
-<c e g> ~ <c e g>
-<c~ e g~ b> <c e g b>
+@lilypond[quote,verbatim]
+\relative c' {
+  <c e g>2~ 2 |
+  <c e g>4~ <c e g c>
+    <c~ e g~ b> <c e g b> |
+}
 @end lilypond
 
 @cindex repeating ties (タイを含む繰り返し)
@@ -462,13 +494,16 @@ a2 ~ 2
 そのような繰り返し部分でのタイは以下のように指定する必要があります:
 
 @c KEEP LY
-@lilypond[quote,relative=2,verbatim]
-\repeat volta 2 { c g <c e>2 ~ }
-\alternative {
-  % 1 番目の差し替え部分: 後に続く音符は通常通りタイで結ばれます
-  { <c e>2. r4 }
-  % 2 番目の差し替え部分: 後に続く音符にはリピート用のタイを付けます
-  { <c e>2\repeatTie d4 c } }
+@lilypond[quote,verbatim]
+\relative {
+  \repeat volta 2 { c'' g <c e>2~ }
+  \alternative {
+    % 1 番目の差し替え部分: 後に続く音符は通常通りタイで結ばれます
+    { <c e>2. r4 }
+    % 2 番目の差し替え部分: 後に続く音符にはリピート用のタイを付けます
+    { <c e>2\repeatTie d4 c }
+  }
+}
 @end lilypond
 
 @cindex laissez vibrer (レセ ヴィブレ)
@@ -491,7 +526,7 @@ L.v. タイは以下のように入力します:
 @funindex \tieDown
 @funindex \tieNeutral
 
-タイを手動で譜の上または下に配置することができます。
+タイを手動で上向きまたは下向きに配置することができます。
 @ref{Direction and placement} を参照してください。
 
 @cindex ties, appearance (タイの見た目)
@@ -506,34 +541,38 @@ L.v. タイは以下のように入力します:
 
 タイを破線、点線、実線と破線の組み合わせにすることができます。
 
-@lilypond[quote, verbatim, relative=1]
-\tieDotted
-c2 ~ 2
-\tieDashed
-c2 ~ 2
-\tieHalfDashed
-c2 ~ 2
-\tieHalfSolid
-c2 ~ 2
-\tieSolid
-c2 ~ 2
+@lilypond[quote, verbatim]
+\relative c' {
+  \tieDotted
+  c2~ 2
+  \tieDashed
+  c2~ 2
+  \tieHalfDashed
+  c2~ 2
+  \tieHalfSolid
+  c2~ 2
+  \tieSolid
+  c2~ 2
+}
 @end lilypond
 
 破線パターンのカスタマイズを指定することができます:
 
-@lilypond[quote, verbatim, relative=1]
-\tieDashPattern #0.3 #0.75
-c2 ~ 2
-\tieDashPattern #0.7 #1.5
-c2 ~ 2
-\tieSolid
-c2 ~ 2
+@lilypond[quote, verbatim]
+\relative c' {
+  \tieDashPattern #0.3 #0.75
+  c2~ 2
+  \tieDashPattern #0.7 #1.5
+  c2~ 2
+  \tieSolid
+  c2~ 2
+}
 @end lilypond
 
 タイの破線パターン定義の構造は、スラーの破線パターン定義と同じです。@c
 複雑な破線パターンについての更なる情報は @ref{Slurs} を参照してください。
 
-譜の中で他のオブジェクトと衝突するタイに対しては、@c
+タイとの間に隙間を作りたいオブジェクトには、@c
 @var{whiteout} レイアウト プロパティと @var{layer} レイアウト プロパティを@c
 オーバライドしてください。
 
@@ -632,9 +671,9 @@ c2 ~ 2
 @c \time 16/1 is used to avoid spurious bar lines
 @c and long tracts of empty measures
 @c KEEP LY
-@lilypond[quote,verbatim,relative=2]
+@lilypond[quote,verbatim]
 \new Staff {
-  % この 2 本線には意味はありません
+  % この 2 行は例を見やすくするためのものです
   \time 16/1
   \omit Staff.TimeSignature
   % 八全休符を譜刻します。二全休符 4 つと等価です
@@ -647,7 +686,7 @@ c2 ~ 2
 }
 @end lilypond
 
-@cindex rest, multi-measure (複数小節の休符)
+@cindex rest, multi-measure (複数小節にまたがる休符)
 @cindex rest, whole-measure (全休符)
 
 全休符 -- 小節の中心に置かれます -- は複数小節の休符として@c
@@ -759,17 +798,17 @@ c2 ~ 2
 空白休符は、音符や休符と同様に、@code{Staff} や @code{Voice} が@c
 存在しない場合に、それらを暗黙的に作成します:
 
-@lilypond[quote,verbatim,fragment]
-s1 s s
+@lilypond[quote,verbatim]
+{ s1 s s }
 @end lilypond
 
 @code{\skip} はただ音楽的な時間をスキップするだけです。@c
 これはいかなる種類の出力も作成しません。
 
 @c KEEP LY
-@lilypond[quote,verbatim,relative=2]
+@lilypond[quote,verbatim]
 % これは有効な入力ですが、何もしません
-\skip 1 \skip1 \skip 1
+{ \skip 1 \skip1 \skip 1 }
 @end lilypond
 
 @seealso
@@ -791,41 +830,45 @@ s1 s s
 @unnumberedsubsubsec 小節単位の休符
 @translationof Full measure rests
 
-@cindex multi-measure rests (複数の小節にまたがる休符)
+@cindex multi-measure rests (複数小節にまたがる休符)
 @cindex full-measure rests (小節単位の休符)
-@cindex rest, multi-measure (複数の小節にまたがる休符)
+@cindex rest, multi-measure (複数小節にまたがる休符)
 @cindex rest, full-measure (小節単位の休符)
 @cindex whole rest for a full measure (小節に対する全休符)
 @cindex rest, whole for a full measure (小節に対する全休符)
 
+@funindex \compressMMRests
 @funindex R
 
 1 つまたは複数の小節に対する休符は@c
 音符名として大文字の @code{R} を持つ音符として入力します:
 
-@lilypond[quote,verbatim,relative=2]
+@c KEEP LY
+@lilypond[quote,verbatim]
 % 休みの小節は 1 つの小節にまとめられます
-\compressFullBarRests
-R1*4
-R1*24
-R1*4
-b2^"Tutti" b4 a4
+\compressMMRests {
+  R1*4
+  R1*24
+  R1*4
+  b'2^"Tutti" b'4 a'4
+}
 @end lilypond
 
 小節単位の休符の演奏時間は、音符に対する演奏時間と同じ表記を使います。@c
 複数小節にまたがる休符の演奏時間は常に小節の長さの整数倍になります。@c
 そのため、しばしばドットや分数を使う必要があります:
 
-@lilypond[quote,verbatim,relative=2]
-\compressFullBarRests
-\time 2/4
-R1 | R2 |
-\time 3/4
-R2. | R2.*2 |
-\time 13/8
-R1*13/8 | R1*13/8*12 |
-\time 10/8
-R4*5*4 |
+@lilypond[quote,verbatim]
+\compressMMRests {
+  \time 2/4
+  R1 | R2 |
+  \time 3/4
+  R2. | R2.*2 |
+  \time 13/8
+  R1*13/8 | R1*13/8*12 |
+  \time 10/8
+  R4*5*4 |
+}
 @end lilypond
 
 1 小節分の休符は、拍子次第で全休符または二全休符のどちらかとして、@c
@@ -843,25 +886,22 @@ R1*2 |
 @cindex multi-measure rest, expanding (複数小節にまたがる休符を展開する)
 @cindex multi-measure rest, contracting (複数小節にまたがる休符をまとめる)
 
-@funindex \expandFullBarRests
-@funindex \compressFullBarRests
-
 デフォルトでは、複数小節にまたがる休符は@c
 休みの小節すべてを明示的に示すように譜刻される楽譜に展開されます。@c
 そうする代わりに、複数小節にまたがる休符を複数小節の休符記号を持つ単一の@c
 小節として譜刻することもできます -- 休みの小節数がその小節の上に譜刻されます。
 
 @c KEEP LY
-@lilypond[quote,verbatim,relative=2]
+@lilypond[quote,verbatim,fragment]
 % デフォルトの振る舞い
 \time 3/4 r2. | R2.*2 |
 \time 2/4 R2 |
 \time 4/4
 % 休みの小節を 1 つの小節にまとめます
-\compressFullBarRests
-r1 | R1*17 | R1*4 |
+\compressMMRests {
+  r1 | R1*17 | R1*4 |
+}
 % 休みの小節を展開します
-\expandFullBarRests
 \time 3/4
 R2.*2 |
 @end lilypond
@@ -883,11 +923,12 @@ R2.*2 |
 フェルマータを付け加えるための定義済みコマンドとして
 @code{\fermataMarkup} が提供されています。
 
-@lilypond[quote,verbatim,relative=2]
-\compressFullBarRests
-\time 3/4
-R2.*10^\markup { \italic "ad lib." }
-R2.^\fermataMarkup
+@lilypond[quote,verbatim]
+\compressMMRests {
+  \time 3/4
+  R2.*10^\markup { \italic "ad lib." }
+  R2.^\fermataMarkup
+}
 @end lilypond
 
 @warning{
@@ -900,7 +941,7 @@ R2.^\fermataMarkup
 }
 
 @c KEEP LY
-@lilypond[quote,verbatim,relative=2]
+@lilypond[quote,verbatim,fragment]
 % この例は誤ったオブジェクト名を指定しているため失敗します
 \override TextScript.padding = #5
 R1^"wrong"
@@ -915,32 +956,28 @@ R1^"right"
 
 @funindex \textLengthOn
 @funindex \textLengthOff
-@funindex textLenthOff
 @funindex \fermataMarkup
-@funindex \compressFullBarRests
-@funindex \expandFullBarRests
+@funindex \compressMMRests
 
 @predefined
 @code{\textLengthOn},
 @code{\textLengthOff},
 @code{\fermataMarkup},
-@code{\compressFullBarRests},
-@code{\expandFullBarRests}
+@code{\compressMMRests}
 @endpredefined
 
 
 @snippets
 
-@c 未訳
-@cindex church rest
-@cindex rest, church
-@cindex kirchenpausen
+@cindex church rest (教会音楽の休符)
+@cindex rest, church (教会音楽の休符)
+@cindex kirchenpausen (教会音楽の休符)
 
 @lilypondfile[verbatim,quote,ragged-right,texidoc,doctitle]
 {changing-form-of-multi-measure-rests.ly}
 
-@cindex multi-measure rests, positioning
-@cindex positioning multi-measure rests
+@cindex multi-measure rests, positioning (複数小節にまたがる休符の位置)
+@cindex positioning multi-measure rests (複数小節にまたがる休符の位置)
 
 @lilypondfile[verbatim,quote,ragged-right,texidoc,doctitle]
 {positioning-multi-measure-rests.ly}
@@ -1013,7 +1050,9 @@ R1^"right"
 \time 3/4 c''2.
 @end lilypond
 
-@cindex time signature, visibility of (拍子の可視性)
+小節の途中で拍子記号を変更することについては、@ref{上拍}で扱っています。
+
+@cindex time signature visibility (拍子の可視性)
 
 拍子は楽曲の始まりと拍子が変更されたときに譜刻されます。@c
 行の終わりで変更が起こる場合、警告の拍子が行の終わりに譜刻されます。@c
@@ -1041,41 +1080,57 @@ R1^"right"
 2/2 や 4/4 で使用される拍子は数字を使用するスタイルに変更することができます:
 
 @c KEEP LY
-@lilypond[quote,verbatim,relative=2]
-% デフォルトのスタイル
-\time 4/4 c1
-\time 2/2 c1
-% 数字を使うスタイルに変更します
-\numericTimeSignature
-\time 4/4 c1
-\time 2/2 c1
-% デフォルトのスタイルに戻します
-\defaultTimeSignature
-\time 4/4 c1
-\time 2/2 c1
+@lilypond[quote,verbatim]
+\relative c'' {
+  % デフォルトのスタイル
+  \time 4/4 c1
+  \time 2/2 c1
+  % 数字を使うスタイルに変更します
+  \numericTimeSignature
+  \time 4/4 c1
+  \time 2/2 c1
+  % デフォルトのスタイルに戻します
+  \defaultTimeSignature
+  \time 4/4 c1
+  \time 2/2 c1
+}
 @end lilypond
 
 
-定量拍子については @ref{Mensural time signatures} でカバーされています。
+計量拍子については @ref{Mensural time signatures} でカバーされています。
 
 @cindex time signature default settings (拍子のデフォルト設定)
 @cindex autobeaming properties for time signatures (拍子のための自動連桁プロパティ)
 @cindex beaming, time signature default properties (連桁と拍子のデフォルト プロパティ)
 @funindex \overrideTimeSignatureSettings
 
-
-@predefined
-@code{\numericTimeSignature},
-@code{\defaultTimeSignature}
-@endpredefined
-
 譜刻される拍子を設定することに加えて、@c
 @code{\time} コマンドは拍子に基づくプロパティ
 @code{baseMoment}, @code{beatStructure}, それに @code{beamExceptions}
-のデフォルト値も設定します。@c
+の値も設定します。@c
 これらのプロパティにあらかじめ定義されているデフォルト値は
 @file{scm/time-signature-settings.scm} で見つかります。@c
-既存のデフォルト値を変更したり、新しいデフォルト値を変更したりすることができます:
+
+@code{beatStructure} のデフォルトの値は、@code{\time} に省略可能な 1 つ目の@c
+引数を与えることでオーバライドできます:
+
+@lilypond[quote,verbatim]
+\score {
+  \new Staff {
+    \relative {
+      \time 2,2,3 7/8
+      \repeat unfold 7 { c'8 } |
+      \time 3,2,2 7/8
+      \repeat unfold 7 { c8 } |
+    }
+  }
+}
+@end lilypond
+
+また、@code{baseMoment} と @code{beamExceptions} も含めた、全ての拍子に基づく@c
+プロパティのデフォルトの値を一度にセットすることができます。@c
+値は異なる拍子記号について独立に設定できます。@c
+新しい値は同じ拍子記号の @code{\time} コマンドが続く時に有効となります。
 
 @lilypond[quote,verbatim]
 \score {
@@ -1098,7 +1153,7 @@ R1^"right"
 @enumerate
 
 @item
-@code{@var{timeSignatureFraction}}, 拍子を示す分数。
+@code{@var{timeSignatureFraction}}, この設定が適用される、拍子記号を示す分数。
 
 @item
 @code{@var{baseMomentFraction}}, 拍子の基本タイミングの単位となる@c
@@ -1113,39 +1168,6 @@ R1^"right"
 連桁の規則を保持する配列リスト。@c
 @ref{自動連桁の振る舞いを設定する} に説明があります。
 @end enumerate
-
-@code{\overrideTimeSignatureSettings} を保持するコンテキストは、@c
-その @code{\overrideTimeSignatureSettings} 呼び出しが実行される前に@c
-インスタンス化されている必要があります。@c
-このことは、そのようなコンテキストは明示的にインスタンス化するか、@c
-そのコンテキスト内で @code{\overrideTimeSignatureSettings} の前に@c
-音楽を置いておく必要があるということを意味します:
-
-@c KEEP LY
-@lilypond[quote,verbatim]
-\score {
-  \relative c' {
-    % コンテキストがまだインスタンス化されていないため、この呼び出しは失敗します
-    \overrideTimeSignatureSettings
-      4/4        % timeSignatureFraction
-      1/4        % baseMomentFraction
-      3,1        % beatStructure
-      #'()       % beamExceptions
-    \time 4/4
-    c8^\markup {"Beamed (2 2)"}
-    \repeat unfold 7 { c8 } |
-    % この呼び出しは成功します
-    \overrideTimeSignatureSettings
-      4/4        % timeSignatureFraction
-      1/4        % baseMomentFraction
-      3,1        % beatStructure
-      #'()       % beamExceptions
-    \time 4/4
-    c8^\markup {"Beamed (3 1)"}
-    \repeat unfold 7 { c8 } |
-  }
-}
-@end lilypond
 
 @cindex time signature properties, restoring default values (拍子プロパティをデフォルト値に戻す)
 @cindex restoring default properties for time signatures (拍子をデフォルト プロパティに戻す)
@@ -1212,6 +1234,10 @@ R1^"right"
 }
 @end lilypond
 
+これらの拍子記号に基づく変数を変更するさらなる方法 -- 変更の際に@c
+同じ拍子記号がもう一度表示されることを避ける方法 -- については、
+@ref{Setting automatic beam behavior} にあります。
+
 @predefined
 @code{\numericTimeSignature},
 @code{\defaultTimeSignature}
@@ -1228,7 +1254,11 @@ R1^"right"
 
 記譜法リファレンス:
 @ref{Mensural time signatures},
+@ref{Setting automatic beam behavior},
 @ref{Time administration}
+
+インストールされているファイル:
+@file{scm/time-signature-settings.scm}.
 
 コード断片集:
 @rlsr{Rhythms}
@@ -1309,6 +1339,26 @@ R1^"right"
 }
 @end lilypond
 
+@funindex \markLengthOn
+@funindex \markLengthOff
+
+長い休符がある楽器のパート譜では、テンポ表示同士が近づいてしまうことが@c
+あります。@code{\markLengthOn} コマンドは、テンポ表示が重ならないように@c
+水平方向のスペースを追加し、@code{\markLengthOff} はテンポ表示が水平方向の@c
+スペースを無視するデフォルトの挙動に戻します。
+
+@lilypond[verbatim,quote]
+\compressMMRests {
+  \markLengthOn
+  \tempo "Molto vivace"
+  R1*12
+  \tempo "Meno mosso"
+  R1*16
+  \markLengthOff
+  \tempo "Tranquillo"
+  R1*20
+}
+@end lilypond
 
 @snippets
 
@@ -1334,7 +1384,7 @@ R1^"right"
 
 記譜法リファレンス:
 @ref{Formatting text},
-@ref{MIDI output}
+@ref{Creating MIDI output}
 
 コード断片集:
 @rlsr{Staff notation}
@@ -1353,6 +1403,7 @@ R1^"right"
 @cindex measure, partial (部分小節)
 @cindex measure, pickup (ピックアップ小節)
 @cindex pickup measure (ピックアップ小節)
+@cindex time signature, mid-measure (小節の途中の拍子記号)
 
 @funindex measurePosition
 @funindex \partial
@@ -1364,17 +1415,8 @@ R1^"right"
 \partial @var{duration}
 @end example
 
-@noindent
-@code{duration} は、最初の完全な長さを持つ小節の前に置かれる小節の長さです:
-
-@lilypond[quote,verbatim,relative=1]
-\time 3/4
-\partial 8
-e8 | a4 c8 b c4 |
-@end lilypond
-
-@var{duration} は、完全な長さを持つ小節より短い演奏時間であれば、@c
-任意の値を取ることができます:
+@code{\partial} が楽譜の最初で用いられた際には、@code{@var{duration}} は@c
+最初の小節より前にある音楽の長さです。
 
 @lilypond[quote,verbatim]
 \relative {
@@ -1384,26 +1426,43 @@ e8 | a4 c8 b c4 |
 }
 @end lilypond
 
-@code{\partial @var{duration}} を以下のように記述することもできます:
+@code{\partial} が楽譜の最初より後に用いられた際には、@code{@var{duration}}は@c
+現在の小節の @emph{残りの} 長さとなります。新しい番号の小節は作られません。
 
-@example
-\set Timing.measurePosition -@var{duration}
-@end example
-
-この場合、@code{\partial 8} は以下のようになります:
-
-@lilypond[quote,verbatim,relative=1]
-\time 3/4
-\set Timing.measurePosition = #(ly:make-moment -1/8)
-e8 | a4 c8 b c4 |
+@lilypond[quote,verbatim]
+\relative {
+  \set Score.barNumberVisibility = #all-bar-numbers-visible
+  \override Score.BarNumber.break-visibility =
+	    #end-of-line-invisible
+  \time 9/8
+  d''4.~ 4 d8 d( c) b | c4.~ 4. \bar "||"
+  \time 12/8
+  \partial 4.
+  c8( d) e | f2.~ 4 f8 a,( c) f |
+}
 @end lilypond
 
-プロパティ @code{measurePosition} は、@c
-ある時点でその小節はどれくらい演奏済みになっているかを示す有理数を保持します。@c
-このプロパティは @code{\partial} によって負の数にセットされるということに@c
-注意してください:
-すなわち、@code{\partial 4} は内部的に @w{@code{-4}} に翻訳され、@c
-@qq{その小節には 4 分音符が残っている} という意味になります。
+@code{\partial} コマンドは小節の途中で拍子記号が変化する場合に@c
+@emph{必要}ですが、単独で使われることもあります。
+
+@lilypond[quote,verbatim]
+\relative {
+  \set Score.barNumberVisibility = #all-bar-numbers-visible
+  \override Score.BarNumber.break-visibility =
+	    #end-of-line-invisible
+  \time 6/8
+  \partial 8
+  e'8 | a4 c8 b[ c b] |
+  \partial 4
+  r8 e,8 | a4 \bar "||"
+  \partial 4
+  r8 e8 | a4
+  c8 b[ c b] |
+}
+@end lilypond
+
+@code{\partial} コマンドは @code{Timing.measurePosition} プロパティを@c
+セットします。これは小節のどれだけが経過したかを表す分数です。
 
 @seealso
 音楽用語集:
@@ -1417,22 +1476,6 @@ e8 | a4 c8 b c4 |
 
 内部リファレンス:
 @rinternals{Timing_translator}
-
-
-@knownissues
-@code{\partial} コマンドは楽曲の開始時でのみ使用すべきです。@c
-楽曲の途中でこのコマンドを使用した場合、@c
-警告や問題が発生する可能性があります。@c
-曲の途中では @code{\partial} の代わりに
-@code{\set Timing.measurePosition} を使用してください。
-
-@lilypond[quote,verbatim,relative=1]
-\time 6/8
-\partial 8
-e8 | a4 c8 b[ c b] |
-\set Timing.measurePosition = #(ly:make-moment -1/4)
-r8 e,8 | a4 c8 b[ c b] |
-@end lilypond
 
 
 @node 無韻律の音楽
@@ -1479,40 +1522,45 @@ r8 e,8 | a4 c8 b[ c b] |
 
 カデンツァが終わると、小節番号が再開されます。
 
-@lilypond[verbatim,relative=2,quote]
-% すべての小節番号を表示します
-\override Score.BarNumber.break-visibility = #all-visible
-c4 d e d
-\cadenzaOn
-c4 c d8[ d d] f4 g4.
-\cadenzaOff
-\bar "|"
-d4 e d c
+@c KEEP LY
+@lilypond[verbatim,quote]
+\relative c'' {
+  % すべての小節番号を表示します
+  \override Score.BarNumber.break-visibility = #all-visible
+  c4 d e d
+  \cadenzaOn
+  c4 c d8[ d d] f4 g4.
+  \cadenzaOff
+  \bar "|"
+  d4 e d c
+}
 @end lilypond
 
-カデンツァの中に @code{\bar} コマンドを挿入したとしても、新しい小節が@c
-始まることはありません。@c
-そのため、注意喚起のための臨時記号は手動で挿入する必要があります。@c
+カデンツァの中に @code{\bar} コマンドを挿入しても、小節線は表示されますが、@c
+新しい小節が始まることはありません。@c
+そのため、全ての臨時記号 -- 通常小節の最後まで効果が持続する --
+は、@code{\bar} による小節線の後でも有効のままです。@c
+もし小節線の後の臨時記号を表示させたいならば、親切の臨時記号 (@code{!}) や@c
+忠告の臨時記号 (@code{?}) を手動で挿入する必要があります。@c
 @ref{Accidentals} を参照してください。
 
-自動連桁は @code{\cadenzaOn} で off になり、@c
-@code{\cadenzaOff} で on になります。@c
-このため、カデンツァ内の連桁はすべて手動で入力する必要があります
-(@ref{手動連桁})。
-
-@lilypond[verbatim,relative=2,quote]
-c4 d e d
-\cadenzaOn
-cis4 d cis d
-\bar "|"
-cis4 d cis! d
-\cadenzaOff
-\bar "|"
+@c KEEP LY
+@lilypond[verbatim,quote]
+\relative c'' {
+  c4 d e d
+  \cadenzaOn
+  cis4 d cis d
+  \bar "|"
+  % 最初の cis は小節線の後ですが、臨時記号無しで表示されます
+  cis4 d cis! d
+  \cadenzaOff
+  \bar "|"
+}
 @end lilypond
 
-自動連桁は @code{\cadenzaOn} によって off になります。@c
-そのため、カデンツァの中に連桁を挿入するには手動で行う必要があります。@c
-@ref{Manual beams} を参照してください。
+自動連桁は @code{\cadenzaOn} で無効になります。@c
+このため、カデンツァ内の連桁はすべて手動で入力する必要があります
+(@ref{手動連桁})。
 
 @lilypond[verbatim,quote]
 \relative {
@@ -1526,10 +1574,6 @@ cis4 d cis! d
 }
 @end lilypond
 
-+These predefined commands affect all staves in the score, even when
-+placed in just one @code{Voice} context.  To change this, move the
-+@code{Timing_translator} from the @code{Score} context to the
-+@code{Staff} context.  See @ref{Polymetric notation}.
 これらの定義済みコマンドは、たとえ @code{Voice} コンテキストの 1 つの@c
 中に配置したとしても、楽譜の中にあるすべての譜に影響を与えます。@c
 これを変更するには、@code{Timing_translator} を @code{Score} コンテキスト@c
@@ -1573,21 +1617,6 @@ cis4 d cis! d
 \bar ""
 @end example
 
-@code{\cadenzaOn} で楽曲を始める場合、@c
-@code{Voice} コンテキストを明示的に作成すべきです。@c
-さもないと、予期しないエラーが発生する可能性があります。
-
-@example
-\new Voice @{
-  \relative c' @{
-    \cadenzaOn
-    c16[^"Solo Free Time" d e f] g2.
-    \bar "||"
-    \cadenzaOff
-  @}
-@}
-@end example
-
 
 @node 多拍子記譜法
 @unnumberedsubsubsec 多拍子記譜法
@@ -1598,14 +1627,14 @@ cis4 d cis! d
 
 @cindex double time signatures (2 重拍子)
 @cindex signatures, polymetric (多拍子)
-@cindex time signatures, polymetric (多拍子)
-@cindex time signatures, double (2 重拍子)
+@cindex time signature, polymetric (多拍子)
+@cindex time signature, double (2 重拍子)
 @cindex polymetric signatures (多拍子)
 @cindex meter, polymetric (多拍子)
 
 @funindex timeSignatureFraction
 @funindex \scaleDurations
-@funindex \times
+@funindex \tuplet
 
 多拍子記譜法がサポートされます。
 複合拍子記譜法がサポートされます。@c
@@ -1613,7 +1642,7 @@ cis4 d cis! d
 伸縮することによる複合拍子のどちらもです。
 
 
-@subsubheading それぞれの譜は異なる拍子を持ち、小節の長さは等価である場合
+@subsubsubheading それぞれの譜は異なる拍子を持ち、小節の長さは等価である場合
 
 各譜共通の拍子記号をセットして、@c
 @code{timeSignatureFraction} にお望みの分数をセットします。@c
@@ -1657,7 +1686,7 @@ cis4 d cis! d
 @end lilypond
 
 
-@subsubheading それぞれの譜は異なる拍子を持ち、小節の長さは等価ではない場合
+@subsubsubheading それぞれの譜は異なる拍子を持ち、小節の長さは等価ではない場合
 
 @code{Timing_translator} と @code{Default_bar_line_engraver} を
 @code{Staff} コンテキストに移すことによって、@c
@@ -1704,9 +1733,9 @@ cis4 d cis! d
 
 @funindex \compoundMeter
 @cindex compound time signatures (複合拍子記号)
-@cindex time signature, compound
+@cindex time signature, compound (複合拍子記号)
 
-@subsubheading 複合拍子記号
+@subsubsubheading 複合拍子記号
 
 複合拍子記号は @code{\compoundMeter} を用いて作成します。@c
 構文は以下の通りです:
@@ -1808,6 +1837,35 @@ cis4 d cis! d
 何小節かで音符がきちんと満たされていない場合、@c
 このエングラーバで挿入されたタイが、それぞれの小節の狂いを示します。
 
+@code{completionUnit} プロパティは音符を分割する際の好ましい長さを指定します。
+
+@lilypond[quote,verbatim]
+\new Voice \with {
+  \remove "Note_heads_engraver"
+  \consists "Completion_heads_engraver"
+} \relative {
+  \time 9/8 g\breve. d''4. \bar "||"
+  \set completionUnit = #(ly:make-moment 3 8)
+  g\breve. d4.
+}
+@end lilypond
+
+これらのエングラーバは、連符のような長さが伸縮された音符に対しては、@c
+入力と同じ伸縮率を保ったまま分割します。
+
+@lilypond[quote,verbatim]
+\new Voice \with {
+  \remove "Note_heads_engraver"
+  \consists "Completion_heads_engraver"
+} \relative {
+  \time 2/4 r4
+  \tuplet 3/2 {g'4 a b}
+  \scaleDurations 2/3 {g a b}
+  g4*2/3 a b
+  \tuplet 3/2 {g4 a b}
+  r4
+}
+@end lilypond
 
 @seealso
 音楽用語集: @rglos{tie}
@@ -1827,12 +1885,10 @@ cis4 d cis! d
 @rinternals{Forbid_line_break_engraver}
 
 @knownissues
-すべての演奏時間を通常の音符と付点で正確に表すことはできません
-(特に、連符を含んでいる場合) が、@c
-@code{Completion_heads_engraver} が連符を挿入することはありません。
-
-@code{Completion_heads_engraver} は音符にだけ作用します。@c
-休符を分割することはありません。
+前のバージョンの挙動を維持するため、@code{c1*2} のような 1 小節より長い@c
+音符や休符は、@code{@{ c1 c1 @}} のように伸縮しない長さに分割されます。@c
+@code{completionFactor} プロパティでこの挙動を調整でき、これを@code{#f} に@c
+セットすることで音符や休符を伸縮することができます。
 
 
 @node 旋律のリズムを示す
@@ -1896,6 +1952,23 @@ cis4 d cis! d
     c4 c8 c c4 c8 c
   }
 >>
+@end lilypond
+
+和音を含む音楽も、まず @code{\reduceChords} 関数で 1 つの音符にまとめることに@c
+よって @code{RhythmicStaff} に入力したり、@code{Pitch_squash_engraver} に@c
+使用することができます。
+
+@lilypond[quote,verbatim]
+\new RhythmicStaff {
+  \time 4/4
+  \reduceChords {
+    <c>2
+    <e>2
+    <c e g>2
+    <c e g>4
+    <c e g>4
+  }
+}
 @end lilypond
 
 
@@ -1975,7 +2048,7 @@ cis4 d cis! d
 @cindex beams, with melismata (メリスマの連桁)
 
 @warning{歌曲の中でメリスマを表すために連桁を使用する場合、@c
-@code{\autoBeamOff} で自動連桁を off にして、手動で連桁を示すべきです。@c
+@code{@bs{}autoBeamOff} で自動連桁を off にして、手動で連桁を示すべきです。@c
 @code{@bs{}partcombine} を @code{@bs{}autoBeamOff} と一緒に@c
 用いると予期しない結果になる可能性があります。@c
 詳細はコード断片集を参照してください。}
@@ -1991,9 +2064,8 @@ cis4 d cis! d
 
 @cindex beams, line breaks (連桁と改行)
 @cindex line breaks, beams (改行と連桁)
-@c 未訳
-@cindex beams, with knee gap
-@cindex knee gap, with beams
+@cindex beams, with knee gap (向きの変わる連桁)
+@cindex knee gap, with beams (向きの変わる連桁)
 @funindex breakable
 
 @snippets
@@ -2044,36 +2116,91 @@ cis4 d cis! d
 
 @funindex autoBeaming
 @funindex baseMoment
-@funindex beamExceptions
+@funindex \beamExceptions
 @funindex beatStructure
 @funindex measureLength
 @funindex \time
 @funindex \set
 
-たいていの場合、自動連桁は拍の終わりで終了します。@c
-拍の終了点はコンテキスト プロパティ @code{baseMoment} と
-@code{beatStructure} によって決定されます。@c
-@code{beatStructure} は @code{baseMoment} を単位とする小節の各拍の@c
-長さを定義する Scheme リストです。@c
-デフォルトでは、@code{baseMoment} は @q{1/拍子の分母} です。@c
-デフォルトでは、各拍の長さは @code{baseMoment} です。
+自動連桁が有効な場合、連桁の配置は以下の 3 つのコンテキスト プロパティによって@c
+決定されます:
+@code{baseMoment}, @code{beatStructure}, @code{beamExceptions}。@c
+これらの値は以下で示すようにオーバライドすることができますが、@c
+@ref{拍子} で説明しているように、デフォルトの値そのものを変更することも@c
+できます。
 
-@lilypond[quote,relative=2,verbatim]
-\time 5/16
-c16^"default" c c c c |
-\set Timing.beatStructure = 2,3
-c16^"(2+3)" c c c c |
-\set Timing.beatStructure = 3,2
-c16^"(3+2)" c c c c |
+@code{beamExceptions} が現在の拍子記号に対して定義されている時、@c
+そのルールのみが連桁の配置の決定に使用されます。
+@code{baseMoment} や @code{beatStructure} の値は使用されません。
+
+@code{beamExceptions} が現在の拍子記号に対して定義されていない時、@c
+@code{baseMoment} と @code{beatStructure} の値によって連桁の配置が決定されます。
+
+
+@subsubsubheading @code{baseMoment} と @code{beatStructure} による連桁
+
+デフォルトで、非常によく使われる拍子に対しては @code{beamExceptions} の@c
+ルールが定義されているため、自動連桁に @code{baseMoment} と
+@code{beatStructure} の値を使用させるためには、@code{beamExceptions} の@c
+ルールを無効化しなければいけません。@code{beamExceptions} はこのようにして@c
+無効化します:
+
+@example
+\set Timing.beamExceptions = #'()
+@end example
+
+@code{beamExceptions} が @code{#'()} にセットされた場合 (明示的にセットされた@c
+場合と、現在の拍子記号に対してルールが定義されていない場合の両方を含みます)、@c
+連桁の終了点は @code{baseMoment} と @code{beatStructure}
+コンテキスト プロパティで指定された拍に従います。@code{beatStructure} は@c
+小節内の各拍の長さが @code{baseMoment} の単位で定義された Scheme リストです。@c
+デフォルトでは、@code{baseMoment} は 1/拍子の分母です。
+
+@code{beatStructure} と @code{baseMoment} の値はそれぞれの拍子記号に対して@c
+別々に存在するということに注意してください。これらの値を変更しても、影響が@c
+及ぶのは現在有効な拍子記号に対してのみです。そのため、これらの変更は@c
+新しい拍子記号のセクションが始まる @code{\time} コマンドの前ではなく後に@c
+置かれなければいけません。ある拍子記号に与えられた新しい値は記憶されており、@c
+その拍子記号が新たに出現した際に再び有効になります。
+
+@c KEEP LY
+@lilypond[quote,verbatim]
+\relative c'' {
+  \time 5/16
+  c16^"default" c c c c |
+  % beamExceptions は 5/16 の拍子については定義されていないようですが、
+  % 念のために無効にしておきましょう
+  \set Timing.beamExceptions = #'()
+  \set Timing.beatStructure = 2,3
+  c16^"(2+3)" c c c c |
+  \set Timing.beatStructure = 3,2
+  c16^"(3+2)" c c c c |
+}
+@end lilypond
+
+@c KEEP LY
+@lilypond[quote,verbatim]
+\relative {
+  \time 4/4
+  a'8^"default" a a a a a a a
+  % beamExceptions は 4/4 に対しては明らかに定義されているため、
+  % これを無効にします
+  \set Timing.beamExceptions = #'()
+  \set Timing.baseMoment = #(ly:make-moment 1/4)
+  \set Timing.beatStructure = 1,1,1,1
+  a8^"changed" a a a a a a a
+}
 @end lilypond
 
 連桁の設定変更をある特定のテキストに限定することができます。@c
 下位コンテキストに連桁の設定が含まれない場合、@c
 そのコンテキストを囲んでいる上位コンテキストの設定が適用されます。
 
-@lilypond[quote, verbatim,relative=1]
+@lilypond[quote, verbatim]
 \new Staff {
   \time 7/8
+  % beamExceptions は 7/8 に対しては定義されていないため
+  % 無効にする必要はありません
   \set Staff.beatStructure = 2,3,2
   <<
     \new Voice = one {
@@ -2097,17 +2224,17 @@ c16^"(3+2)" c c c c |
 @code{Staff} コンテキストで設定を行う必要があります:
 
 @c KEEP LY
-@lilypond[quote,verbatim,relative=2]
+@lilypond[quote,verbatim,fragment]
 \time 7/8
 % リズム 3-1-1-2
 % デフォルトで連桁設定の変更は Voice に適用され、うまくいきません
 % なぜなら、自動生成されるボイスで、すべての拍は baseMoment (1 . 8) だからです
 \set beatStructure = 3,1,1,2
-<< {a8 a a a16 a a a a8 a} \\ {f4. f8 f f f} >>
+<< \relative {a'8 a a a16 a a a a8 a} \\ \relative {f'4. f8 f f f} >>
 
 % コンテキスト Staff を指定するとうまくいきます
 \set Staff.beatStructure = 3,1,1,2
-<< {a8 a a a16 a a a a8 a} \\ {f4. f8 f f f} >>
+<< \relative {a'8 a a a16 a a a a8 a} \\ \relative {f'4. f8 f f f} >>
 @end lilypond
 
 @code{baseMoment} の値を調整することで、@c
@@ -2116,54 +2243,45 @@ c16^"(3+2)" c c c c |
 @code{beatStructure} に新しい @code{baseMoment} と矛盾しない値を@c
 設定する必要があります。
 
-@lilypond[quote,verbatim,relative=2]
+@c KEEP LY
+@lilypond[quote,verbatim,fragment]
 \time 5/8
+% beamExceptions は 5/8 に対しては定義されていないため
+% 無効にする必要はありません
 \set Timing.baseMoment = #(ly:make-moment 1/16)
 \set Timing.beatStructure = 7,3
-\repeat unfold 10 { a16 }
+\repeat unfold 10 { a'16 }
 @end lilypond
 
 @code{beatLength} は @i{moment} -- 演奏時間の単位 -- です。@c
-タイプ @i{momento} の量は
+タイプ @i{moment} の量は
 Scheme 関数 @code{ly:make-moment} によって作り出されます。@c
 この関数についての更なる情報は @ref{Time administration} を参照してください。
 
 デフォルトでは、@code{baseMoment} には「1/拍子の分母」がセットされています。@c
 このデフォルトの例外は @file{scm/time-signature-settings.scm} で見つかります。
 
+@subsubsubheading @code{beamExceptions} に基づいた連桁
+
 特殊な自動連桁規則 (連桁の終わりが拍に従わないもの) はプロパティ
 @code{beamExceptions} に定義します。
 
-@c 未訳
-@lilypond[quote,relative=2,verbatim]
-\time 3/16
-\set Timing.beatStructure = 2,1
-\set Timing.beamExceptions =
-  #'(                         ;start of alist
-     (end .                   ;entry for end of beams
-      (                       ;start of alist of end points
-       ((1 . 32) . (2 2 2))   ;rule for 1/32 beams -- end each 1/16
-      )))                     %close all entries
-c16 c c |
-\repeat unfold 6 { c32 } |
+@code{beamExceptions} の値は -- 少し複雑な Scheme データ構造ですが -- は、
+@code{\beamExceptions} 関数によって非常に簡単に生成できます。@c
+この関数には 1 つ以上の手動連桁を含む、小節の長さのリズムパターンを与えます
+(小節は小節チェック記号@tie{|} で分割されている必要があります。この関数では@c
+他に小節の長さを識別する方法が無いためです)。簡単な例を示します:
+
+@lilypond[quote,verbatim]
+\relative c'' {
+  \time 3/16
+  \set Timing.beatStructure = 2,1
+  \set Timing.beamExceptions =
+    \beamExceptions { 32[ 32] 32[ 32] 32[ 32] }
+  c16 c c |
+  \repeat unfold 6 { c32 } |
+}
 @end lilypond
-
-@code{beamExceptions} は規則タイプのキーと連桁規則の値を持つ配列リストです。
-
-現時点で、利用可能な唯一の規則タイプの値は、@c
-連桁の終わりのための @code{'end} です。
-
-連桁規則は、連桁タイプとその連桁タイプの最短演奏時間の音符を保持する連桁に@c
-適用されるグループ化の仕方を示す Scheme 配列リスト (あるいはペアのリスト) です。
-
-@example
-#'((beam-type1 . grouping-1)
-   (beam-type2 . grouping-2)
-   (beam-type3 . grouping-3))
-@end example
-
-連桁タイプは、その連桁の演奏時間を示す Scheme ペアであり、@c
-例えば @code{(1 . 16)} です。
 
 @warning{@code{beamExceptions} の値は @emph{完全な} 例外リストである@c
 必要があります。@c
@@ -2179,15 +2297,17 @@ c16 c c |
 デフォルトの振る舞いにリセットされます。
 
 @c KEEP LY
-@lilypond[quote,verbatim,relative=2]
-\time 6/8
-\repeat unfold 6 { a8 }
-% (4 + 2) にグループ化します
-\set Timing.beatStructure = 4,2
-\repeat unfold 6 { a8 }
-% デフォルトの振る舞いに戻ります
-\time 6/8
-\repeat unfold 6 { a8 }
+@lilypond[quote,verbatim]
+\relative a' {
+  \time 6/8
+  \repeat unfold 6 { a8 }
+  % (4 + 2) にグループ化します
+  \set Timing.beatStructure = 4,2
+  \repeat unfold 6 { a8 }
+  % デフォルトの振る舞いに戻ります
+  \time 6/8
+  \repeat unfold 6 { a8 }
+}
 @end lilypond
 
 ある拍子に対するデフォルトの自動連桁設定は @file{scm/beam-settings.scm}
@@ -2203,15 +2323,15 @@ c16 c c |
 オーバライドすることができます。
 
 @c KEEP LY
-@lilypond[quote,verbatim,relative=2]
+@lilypond[quote,verbatim,fragment]
 \time 4/4
 \set Timing.baseMoment = #(ly:make-moment 1/8)
 \set Timing.beatStructure = 3,3,2
 % 以下は beamExceptions のため、(3 3 2) の連桁にはなりません
-\repeat unfold 8 {c8} |
+\repeat unfold 8 {c''8} |
 % 以下は beamExceptions をクリアするため、(3 3 2) の連桁になります
 \set Timing.beamExceptions = #'()
-\repeat unfold 8 {c8}
+\repeat unfold 8 {c''8}
 @end lilypond
 
 同様に、3/4 拍子はデフォルトで 8 分音符しかない小節を 1 つの連桁で囲み@c
@@ -2220,13 +2340,13 @@ c16 c c |
 リセットします。
 
 @c KEEP LY
-@lilypond[quote,verbatim,relative=2]
+@lilypond[quote,verbatim,fragment]
 \time 3/4
 % beamExceptions により、デフォルトで (6) の連桁を付けます
-\repeat unfold 6 {a8} |
+\repeat unfold 6 {a'8} |
 % beatLength により、これは (1 1 1) の連桁を付けます
 \set Timing.beamExceptions = #'()
-\repeat unfold 6 {a8}
+\repeat unfold 6 {a'8}
 @end lilypond
 
 ロマン派や古典派時代の譜刻では、3/4 拍子の小節の途中から連桁が始まる@c
@@ -2245,7 +2365,7 @@ c16 c c |
 }
 @end lilypond
 
-@i{@strong{自動連桁はどのように機能するのか}}
+@subsubsubheading 自動連桁はどのように機能するのか
 
 自動連桁が有効である場合、自動連桁の配置はコンテキスト プロパティ
 @code{baseMoment}, @code{beatStructure}, それに @code{beamExceptions}
@@ -2255,7 +2375,7 @@ c16 c c |
 
 @itemize
 
-@item @code{[..]} で手動連桁が指定されている場合、@c
+@item @code{[@dots{}]} で手動連桁が指定されている場合、@c
 連桁は指定どおりに設定されます。@c
 手動連桁が指定されていない場合、
 
@@ -2289,8 +2409,7 @@ c16 c c |
 @lilypondfile[verbatim,quote,ragged-right,texidoc,doctitle]
 {subdividing-beams.ly}
 
-@c 未訳
-@cindex beamlets, orienting
+@cindex beamlets, orienting (16 分音符以下の連桁の向き)
 
 @lilypondfile[verbatim,quote,ragged-right,texidoc,doctitle]
 {strict-beat-beaming.ly}
@@ -2310,8 +2429,11 @@ c16 c c |
 {beam-endings-in-score-context.ly}
 
 @seealso
+記譜法リファレンス:
+@ref{拍子}
+
 インストールされているファイル:
-@file{scm/beam-settings.scm}
+@file{scm/time-signature-settings.scm}
 
 コード断片集:
 @rlsr{Rhythms}
@@ -2339,16 +2461,17 @@ c16 c c |
 前にある譜でセットしたカスタム連桁はリセットされます。@c
 この問題を回避する方法の 1 つは、拍子の設定は 1 つの譜でしか行わないことです。
 
-@lilypond[quote,verbatim,relative=2]
+@lilypond[quote,verbatim]
 <<
   \new Staff {
     \time 3/4
     \set Timing.baseMoment = #(ly:make-moment 1/8)
     \set Timing.beatStructure = 1,5
-    \repeat unfold 6 { a8 }
+    \set Timing.beamExceptions = #'()
+    \repeat unfold 6 { a'8 }
   }
   \new Staff {
-    \repeat unfold 6 { a8 }
+    \repeat unfold 6 { a'8 }
   }
 >>
 @end lilypond
@@ -2663,25 +2786,38 @@ MIDI 出力での演奏時間は正確です。
 @end lilypond
 
 @noindent
-さらに、繰り返しの小節線が 5 種類あります:
+さらに、繰り返しの小節線が 9 種類あります:
 
-@lilypond[quote,relative=1,verbatim]
-f1 \bar ".|:"
-g1 \bar ":..:"
-a1 \bar ":|.|:"
-b1 \bar ":|.:"
-c1 \bar ":|."
-e1
+@lilypond[quote,verbatim]
+\relative {
+  f'1 \bar ".|:"
+  g1 \bar ":..:"
+  a1 \bar ":|.|:"
+  b1 \bar ":|.:"
+  c1 \bar ":.|.:"
+  d1 \bar "[|:"
+  e1 \bar ":|][|:"
+  f1 \bar ":|]"
+  g1 \bar ":|."
+  a1
+}
 @end lilypond
 
-@c 未訳
-Additionally, a bar line can be printed as a simple tick:
-@lilypond[quote,relative=1,verbatim]
-f1 \bar "'"
+更に、小節線は単純な短線として表示することができます:
+@lilypond[quote,fragment,verbatim]
+f'1 \bar "'" g'1
 @end lilypond
-However, as such ticks are typically used in Gregorian chant, it is preferable
-to use @code{\divisioMinima} there instead, described in the section
-@ref{Divisiones} in Gregorian chant.
+しかし、このような短線は通常、グレゴリア聖歌の中で使われます。そこでは代わりに
+@code{\divisioMinima} を用いるほうが良いです。グレゴリア聖歌の
+@ref{Divisiones} セクションで説明してあります。
+
+LilyPond は Kievan 記譜法をサポートしており、特殊な Kievan の小節線を@c
+入力することができます:
+@lilypond[quote,fragment,verbatim]
+f'1 \bar "k"
+@end lilypond
+この記譜法に関する更なる情報は、@ref{Typesetting Kievan square notation} に@c
+説明してあります。
 
 @cindex segno (セーニョ)
 
@@ -2716,8 +2852,8 @@ to use @code{\divisioMinima} there instead, described in the section
 (@ref{Repeats} を参照してください)。@c
 繰り返しのコマンドは自動的に適切な小節線を譜刻します。
 
-さらに、@code{"||:"} を使用することができます。@c
-これは @code{"|:"} と等価ですが、例外として改行位置では、@c
+さらに、@code{".|:-||"} を使用することができます。@c
+これは @code{".|:"} と等価ですが、例外として改行位置では、@c
 この小節線は行の終わりに 2 重線の小節線を置き、@c
 次の行の始めに繰り返し開始の小節線を置きます。
 
@@ -2764,9 +2900,99 @@ to use @code{\divisioMinima} there instead, described in the section
 @end lilypond
 
 さらに、@code{\inStaffSegno} コマンドがあります。@c
-これは、セーニョ小節線を作り出し、@code{\repeat volta} コマンドと連携@c
-します。
+これは、@code{\repeat volta} コマンドと@c
+用いられた際に、繰り返しの小節線と結合したセーニョ小節線を作り出します。@c
+@ref{通常の繰り返し} を参照してください。
 
+@funindex \defineBarLine
+@cindex bar lines, defining (小節線を定義する)
+@cindex defining bar lines (小節線を定義する)
+
+@code{\defineBarLine} を用いて、新しい小節線を定義することができます:
+
+@example
+\defineBarLine @var{bartype} #'(@var{end} @var{begin} @var{span})
+@end example
+
+@code{\defineBarline} の引数は@q{空の}文字列 @code{""} を含むことができ、@c
+これは不可視の小節線を作り出します。または、@code{#f} にセットすることで、@c
+何の小節線も表示しないようにすることができます。
+
+定義した後、新しい小節線は @code{\bar} @var{bartype} で使用することができます。
+
+現在使用できる小節線の要素は 10 個存在します:
+
+@lilypond[quote,verbatim]
+\defineBarLine ":" #'("" ":" "")
+\defineBarLine "=" #'("=" "" "")
+\defineBarLine "[" #'("" "[" "")
+\defineBarLine "]" #'("]" "" "")
+
+\new Staff {
+  s1 \bar "|"
+  s1 \bar "."
+  s1 \bar "!"
+  s1 \bar ";"
+  s1 \bar ":"
+  s1 \bar "k"
+  s1 \bar "S"
+  s1 \bar "="
+  s1 \bar "["
+  s1 \bar "]"
+  s1 \bar ""
+}
+@end lilypond
+
+@code{"="} 小節線は、セーニョ記号と組み合わせて使うための二重の小節線を@c
+提供します。二重の細い小節線を単独で表示させるためにをこれを使わないで@c
+ください。@code{\bar} @var{"||"} を使ってください。
+
+@code{"-"} 記号は、小節線に注釈を入れるために使用します。これは、@c
+同じ見た目をしていても改行によって挙動が変化する場合や、@c
+譜をまたぐ小節線の見た目が異なる場合に区別するのに便利です。@c
+@code{"-"} の後に続く部分は、小節線を構築する際に使用されません。
+
+@lilypond[quote,verbatim]
+\defineBarLine "||-dashedSpan" #'("||" "" "!!")
+
+\new StaffGroup <<
+  \new Staff \relative c'' {
+    c1 \bar "||"
+    c1 \bar "||-dashedSpan"
+    c1
+  }
+  \new Staff \relative c'' {
+    c1
+    c1
+    c1
+  }
+>>
+@end lilypond
+
+更に、スペース文字 @code{" "} は、譜をまたぐ小節線がメインの小節線に@c
+正しく揃うようにするプレース ホルダとして機能します:
+
+@lilypond[quote,verbatim]
+\defineBarLine ":|.-wrong" #'(":|." "" "|.")
+\defineBarLine ":|.-right" #'(":|." "" " |.")
+
+\new StaffGroup <<
+  \new Staff \relative c'' {
+    c1 \bar ":|.-wrong"
+    c1 \bar ":|.-right"
+    c1
+  }
+  \new Staff \relative c'' {
+    c1
+    c1
+    c1
+  }
+>>
+@end lilypond
+
+小節線の要素を追加したい場合、LilyPond はそれらを定義するシンプルな手段を@c
+提供しています。小節線の変更あるいは追加に関する更なる情報は、@c
+ファイル @file{scm/bar-line-.scm} を参照してください。
 
 多くの譜を持つ楽譜では、ある譜の @code{\bar} コマンドは@c
 自動的にすべての譜に適用されます。@c
@@ -2791,8 +3017,6 @@ to use @code{\divisioMinima} there instead, described in the section
 @cindex default bar lines, changing (デフォルトの小節線を変更する)
 @cindex bar lines, default, changing (デフォルトの小節線を変更する)
 
-@snippets
-
 @funindex whichBar
 @funindex defaultBarType
 @funindex \bar
@@ -2812,6 +3036,9 @@ to use @code{\divisioMinima} there instead, described in the section
 @ref{Line breaking},
 @ref{Repeats},
 @ref{Grouping staves}
+
+インストールされているファイル:
+@file{scm/bar-line.scm}
 
 コード断片集:
 @rlsr{Rhythms}
@@ -2838,11 +3065,13 @@ to use @code{\divisioMinima} there instead, described in the section
 通常は各小節で自動的に更新されます。@c
 小節番号を手動で設定することも可能です:
 
-@lilypond[verbatim,quote,fragment,relative=1]
-c1 c c c
-\break
-\set Score.currentBarNumber = #50
-c1 c c c
+@lilypond[verbatim,quote]
+\relative c' {
+  c1 c c c
+  \break
+  \set Score.currentBarNumber = #50
+  c1 c c c
+}
 @end lilypond
 
 @cindex bar numbers, regular spacing  規則的な間隔で小節番号を譜刻する
@@ -2864,14 +3093,17 @@ c1 c c c
 (行の終了点での可視性、行の途中での可視性、行の開始点での可視性) です。@c
 以下の例では、譜刻可能な場所すべてに小節番号を譜刻しています:
 
-@lilypond[verbatim,quote,relative=1]
-\override Score.BarNumber.break-visibility = #'#(#t #t #t)
-\set Score.currentBarNumber = #11
-% Permit first bar number to be printed
-\bar ""
-c1 | c | c | c
-\break
-c1 | c | c | c
+@c KEEP LY
+@lilypond[verbatim,quote]
+\relative c' {
+  \override Score.BarNumber.break-visibility = ##(#t #t #t)
+  \set Score.currentBarNumber = #11
+  % 最初の小節番号が表示されるようにします
+  \bar ""
+  c1 | c | c | c |
+  \break
+  c1 | c | c | c |
+}
 @end lilypond
 
 @snippets
@@ -2880,6 +3112,9 @@ c1 | c | c | c
 
 @lilypondfile[verbatim,quote,ragged-right,texidoc,doctitle]
 {printing-bar-numbers-at-regular-intervals.ly}
+
+@lilypondfile[verbatim,quote,ragged-right,texidoc,doctitle]
+{printing-bar-numbers-with-changing-regular-intervals.ly}
 
 @cindex measure number, format (小節番号のフォーマット)
 @cindex bar number, format (小節番号のフォーマット)
@@ -2942,6 +3177,15 @@ c1 | c | c | c
 \time 3/4 c2 e4 | g2 |
 @end example
 
+正しくない演奏時間は滅茶苦茶な楽譜を生成する可能性があります
+-- 特にその楽譜が多声である場合はそうなる可能性があります。@c
+入力を修正するには、@c
+まずざっと見て失敗した小節チェックと演奏時間の誤りを探すと良いでしょう。
+
+連続する小節チェックは同じ音楽的間隔で off になり、@c
+最初の警告メッセージだけが表示されます。@c
+これにより、警告の焦点がタイミング エラーの発生源に絞られます。
+
 歌詞でも小節チェックを使用することができます。@c
 以下に例を挙げます:
 
@@ -2952,15 +3196,10 @@ c1 | c | c | c
 @}
 @end example
 
-正しくない演奏時間は滅茶苦茶な楽譜を生成する可能性があります
--- 特にその楽譜が多声である場合はそうなる可能性があります。@c
-入力を修正するには、@c
-まずざっと見て失敗した小節チェックと演奏時間の誤りを探すと良いでしょう。
-
-連続する小節チェックは同じ音楽的間隔で off になり、@c
-最初の警告メッセージだけが表示されます。@c
-これにより、警告の焦点がタイミング エラーの発生源に絞られます。
-
+歌詞での小節チェック マークは、マークが処理されて@emph{その次の}音節が出現する@c
+タイミングで評価されます。もし歌詞が、小節の最初に休符を持つボイスと@c
+関連づいているなら、その小節の最初に配置できる音節が存在せず、@c
+警告が表示されます。
 
 @funindex |
 @funindex "|"
@@ -3092,9 +3331,9 @@ c1 | c | c | c
 @end lilypond
 
 ファイル @file{scm/translation-functions.scm} は
-@code{format-mark-numbers} (デフォルトのフォーマット),
-@code{format-mark-box-numbers}, @code{format-mark-letters} それに
-@code{format-mark-box-letters} の定義を保持しています。@c
+@code{format-mark-letters} (デフォルトのフォーマット),
+@code{format-mark-box-letters}, @code{format-mark-numbers} それに
+@code{format-mark-box-numbers} の定義を保持しています。@c
 これらを参考にして他のフォーマット関数を作り出すこともできます。
 
 加算された数字や文字の代わりに小節番号を取得するために
@@ -3117,7 +3356,7 @@ c1 | c | c | c
 
 @cindex segno (セーニョ)
 @cindex coda (コーダ)
-@cindex D.S al Fine (ここで曲の先頭に戻り、Fine で終わる)
+@cindex D.S. al Fine (ここで曲の先頭に戻り、Fine で終わる)
 @cindex fermata (フェルマータ)
 @cindex music glyphs (音楽的図柄)
 @cindex glyphs, music (音楽的図柄)
@@ -3206,17 +3445,11 @@ c1 | c | c | c
 @emph{acciaccatura} (長さを持たない装飾小音符で、@c
 スラーでつなげられるスラッシュ付きの符幹を持つ音符) と、
 @emph{appoggiatura} (一定の比率で主音符から演奏時間を取り、@c
-スラッシュを持たない音符)
+スラッシュを持たない音符) です。@c
 スラーで結ばれた主音符の間に装飾小音符を配置するために、@c
 @code{\slashedGrace} 関数を用いて、
 @emph{acciaccatura} のようにスラッシュ付きの符幹を持つが@c
 スラーは付かない装飾小音符を譜刻することもできます。
-
-LilyPond はさらに 2 つ特殊なタイプの装飾小音符をサポートします:
-@emph{acciaccatura} (長さを持たない装飾小音符で、@c
-スラッシュ付きの符幹を持つスラーでつなげられる小さな音符) と
-@emph{appoggiatura} (一定の比率で主音符から演奏時間をとり、@c
-スラッシュを持たない小さな音符で譜刻されます) です。
 
 @lilypond[quote,verbatim]
 \relative {
@@ -3253,12 +3486,21 @@ LilyPond はさらに 2 つ特殊なタイプの装飾小音符をサポート�
 \relative { c''1 \afterGrace d1 { c16[ d] } c1 }
 @end lilypond
 
-これは主音符の長さの 3/4 のスペースをとった後に@c
-装飾小音符を配置しています。@c
-デフォルトの分数 3/4 は @code{afterGraceFraction} を設定することにより@c
-変更することができます。@c
-以下の例では、スペースをデフォルト、主音符の 15/16、最後は 1/2 に@c
-設定した結果を示しています。
+これは主音符の@emph{後に}装飾小音符を配置します。@c
+装飾小音符がどのタイミングで配置されるかは、主音符の長さとの割合で@c
+決められます。以下に示すデフォルトの設定はトップレベルで@c
+再定義することができます:
+
+@example
+afterGraceFraction = 3/4
+@end example
+
+@noindent
+代わりに、個々の @code{\afterGrace} コマンドの直後に分数を与えることで@c
+割合を指定することもできます。
+
+次の例は順に、デフォルトのスペース、主音符の @code{15/16} に指定した場合、@c
+主音符の @code{1/2} に指定した場合の結果を示しています。
 
 @lilypond[quote,verbatim]
 <<
@@ -3266,18 +3508,15 @@ LilyPond はさらに 2 つ特殊なタイプの装飾小音符をサポート�
     c''1 \afterGrace d1 { c16[ d] } c1
   }
   \new Staff \relative {
-    #(define afterGraceFraction (cons 15 16))
-    c''1 \afterGrace d1 { c16[ d] } c1
+    c''1 \afterGrace 15/16 d1 { c16[ d] } c1
   }
   \new Staff \relative {
-    #(define afterGraceFraction (cons 1 2))
-    c''1 \afterGrace d1 { c16[ d] } c1
+    c''1 \afterGrace 1/2 d1 { c16[ d] } c1
   }
 >>
 @end lilypond
 
-主音符と装飾小音符の間のスペースは空白音符を使って@c
-指定することもできます。@c
+@code{\afterGrace} の効果は、空白休符を用いても得ることができます。@c
 以下の例では、主音符の長さの 7/8 のスペースをとった後に装飾小音符を@c
 配置しています。
 
@@ -3352,6 +3591,7 @@ LilyPond はさらに 2 つ特殊なタイプの装飾小音符をサポート�
 内部リファレンス:
 @rinternals{GraceMusic},
 @rinternals{Grace_beam_engraver},
+@rinternals{Grace_auto_beam_engraver},
 @rinternals{Grace_engraver},
 @rinternals{Grace_spacing_engraver}
 
@@ -3392,32 +3632,9 @@ LilyPond はさらに 2 つ特殊なタイプの装飾小音符をサポート�
 >>
 @end lilypond
 
-ボイス コンテキストの中で装飾送音符を記述すると、@c
-ボイスの譜刻に混乱を招きます。@c
-これを克服するには、装飾小音符のセクションを変数に入れます。
-
-@lilypond[quote,verbatim]
-accMusic = {
-  \acciaccatura { f8 } e8 r8 \acciaccatura { f8 } e8 r4
-}
-
-\new Staff {
-  <<
-    \new Voice {
-      \relative c'' {
-        r8 r8 \voiceOne \accMusic \oneVoice r8 |
-        r8 \voiceOne r8 \accMusic \oneVoice r8 |
-      }
-    }
-    \new Voice {
-      \relative c' {
-        s8 s8 \voiceTwo \accMusic \oneVoice s8 |
-        s8 \voiceTwo r8 \accMusic \oneVoice s8 |
-      }
-    }
-  >>
-}
-@end lilypond
+実際の音符部分には @code{\acciaccatura} や @code{\appoggiatura} を用いていたと@c
+しても、空白休符の部分には @code{\grace} コマンドを用いるようにしてください。@c
+そうしないと、見えない装飾小音符と次の音符とを繋ぐ、醜いスラーが表示されます。
 
 装飾小音符セクションはシーケンシャルな音楽表記の中でのみ使用すべきです。@c
 装飾小音符セクションのネスト、並置はサポートされておらず、@c
@@ -3430,19 +3647,19 @@ MIDI 出力において装飾小音符はそれぞれ 1/4 の実演奏時間を�
 例えば:
 
 @example
-\acciaccatura @{ c'8[ d' e' f' g'] @}
+c'8 \acciaccatura @{ c'8[ d' e' f' g'] @}
 @end example
 
 を以下のようにします:
 
 @example
-\acciaccatura @{ c'16[ d' e' f' g'] @}
+c'8 \acciaccatura @{ c'16[ d' e' f' g'] @}
 @end example
 
 あるいは、明示的に演奏時間を変更します:
 
 @example
-\acciaccatura @{ \scaleDurations 1/2 @{ c'8[ d' e' f' g'] @} @}
+c'8 \acciaccatura @{ \scaleDurations 1/2 @{ c'8[ d' e' f' g'] @} @}
 @end example
 
 @ref{Scaling durations} を参照してください。
@@ -3567,10 +3784,10 @@ MyCadenza = \relative {
 @end lilypond
 
 @noindent
-この例が示すように、@code{ly:make-moment n m} は全音符の n/m の長さの@c
+この例が示すように、@code{ly:make-moment n/m} は全音符の n/m の長さの@c
 演奏時間を構成します。@c
-例えば、@code{ly:make-moment 1 8} は 1 個の 8 分音符の演奏時間であり、@c
-@code{ly:make-moment 7 16} は 7 個の 16 分音符の演奏時間です。
+例えば、@code{ly:make-moment 1/8} は 1 個の 8 分音符の演奏時間であり、@c
+@code{ly:make-moment 7/16} は 7 個の 16 分音符の演奏時間です。
 
 @seealso
 記譜法リファレンス:

--- a/Documentation/ja/notation/simultaneous.itely
+++ b/Documentation/ja/notation/simultaneous.itely
@@ -1,6 +1,6 @@
 @c -*- coding: utf-8; mode: texinfo; documentlanguage: ja -*-
 @ignore
-    Translation of GIT committish: c1b0482f63f881bd3f67845e5f76a3e04675ef2a
+    Translation of GIT committish: eb38c33a95cbe6adf9f176dfbb794373ec062605
 
     When revising a translation, copy the HEAD committish of the
     version that you are working on.  See TRANSLATION for details.
@@ -9,7 +9,7 @@
 @c \version "2.19.29"
 
 
-@c Translators: Yoshiki Sawada
+@c Translators: Tomohiro Tatejima, Yoshiki Sawada
 @c Translation status: post-GDP
 
 
@@ -81,9 +81,11 @@ LilyPond の中で多声部は同じ譜にある複数のボイスを参照し�
 @end lilypond
 
 しかしながら、いくつかの記譜要素
--- 強弱記号、ヘアピン、それにスラーなど --
+-- 強弱記号、ヘアピンなど --
 は和音の中の音符ではなく、和音に付ける必要があります。@c
-そうしなければ、譜刻されません。
+そうしなければ、譜刻されません。@c
+運指やスラーなどの他の記譜要素が和音の中の音符に付けられた場合、@c
+和音全体や単音に付けた場合と比べて配置が明らかに変化します。
 
 @lilypond[verbatim,quote]
 \relative {
@@ -92,9 +94,8 @@ LilyPond の中で多声部は同じ譜にある複数のボイスを参照し�
 }
 @end lilypond
 
-@c ここから L2100
 @cindex chords, empty (空の和音)
-@cindex placeholder events ()
+@cindex placeholder events (プレースホルダー イベント)
 
 和音は和音に含まれる音符、アーティキュレーション、それに他の付属要素の@c
 コンテナにすぎません。@c
@@ -168,8 +169,9 @@ LilyPond の中で多声部は同じ譜にある複数のボイスを参照し�
 @unnumberedsubsubsec 和音の繰り返し
 @translationof Chord repetition
 
-@cindex Chord, repetition (和音の繰り返し)
+@cindex chord, repetition (和音の繰り返し)
 @cindex repetition, using @code{q} (@code{q} を用いた繰り返し)
+@cindex @code{q}, chord repetition (@code{q} を用いた和音の繰り返し)
 
 入力の手間を省くために、前の和音を繰り返すための短縮記法があります。@c
 和音を繰り返すためのシンボルは @code{q} です:
@@ -227,26 +229,24 @@ LilyPond の中で多声部は同じ譜にある複数のボイスを参照し�
 ことで予期しない結果になっています:
 @code{\chordRepeats} の和音イベントが展開されると、@c
 通常どおりに入力された和音と区別が付かず、@c
-@code{\relative} はカレントのコンテキストに基づいて音程を割り当てます。
+@code{\relative} は現在の状態に基づいてオクターブを割り当てます。
 
 ネストされた @code{\relative} のインスタンスは内外のインスタンスに@c
 影響を与えないので、@c
 @code{\chordRepeats} の内側に @code{\relative} を配置することで@c
-@code{\chordRepeats} の和音を展開する前に音程を確定させることができます。@c
-今回のケースでは、内側にある @code{\relative} の内容は@c
+@code{\chordRepeats} の和音を展開する前にオクターブを確定させることが@c
+できます。今回のケースでは、内側にある @code{\relative} の内容は@c
 外側にある @code{\relative} の影響を受けないので、@c
 繰り返しの和音は前の和音の音程を維持しています。@c
 また、内側の @code{\relative} は外側の @code{\relative} に影響を与えないので、@c
 最後の音符のオクターブ入力が変化します。
 
-@c Without \new Voice, implicit voice creation does the dumbest thing.
 @lilypond[verbatim,quote]
-\new Voice
-\relative c'' {
+\relative {
   \chordRepeats #'(articulation-event)
   \relative
   { <a'-. c\prall e>1\sfz c'4 q2 r8 q8-. } |
-  q2 c |
+  q2 c'' |
 }
 @end lilypond
 
@@ -284,6 +284,7 @@ LilyPond の中で多声部は同じ譜にある複数のボイスを参照し�
 }
 @end lilypond
 
+@c KEEP LY
 @lilypond[quote,verbatim]
 \relative {
   % 単一の音符で始まります
@@ -320,7 +321,6 @@ LilyPond の中で多声部は同じ譜にある複数のボイスを参照し�
 ここでは、リズムが異なっていても問題ありません。@c
 異なるボイスだと解釈されるからです。
 
-@cindex collisions, clashing note columns (音符列の衝突)
 @cindex collisions, ignoring (衝突を無視する)
 
 @knownissues
@@ -329,7 +329,7 @@ LilyPond の中で多声部は同じ譜にある複数のボイスを参照し�
 コンパイル中に以下のメッセージが表示されます:
 
 @example
-warning: ignoring too many clashing note columns
+warning: This voice needs a \voiceXx or \shiftXx setting
 @end example
 
 
@@ -404,6 +404,7 @@ warning: ignoring too many clashing note columns
 * 単一譜の多声::
 * ボイス スタイル::
 * 衝突の解決::
+* 休符のマージ::
 * 自動パート結合::
 * 音楽を並列に記述する::
 @end menu
@@ -447,13 +448,13 @@ warning: ignoring too many clashing note columns
 向きに戻します。
 
 @c passage: 楽節
-@subsubsubheading 一時的に多声となる楽節 (passage)
+@subsubsubheading 一時的に多声となる楽節 (パッセージ)
 
 一時的に多声となる楽節は以下のような構成で作成することができます:
 
 @example
-<< @{ \voiceOne ... @}
-  \new Voice @{ \voiceTwo ... @}
+<< @{ \voiceOne @dots{} @}
+  \new Voice @{ \voiceTwo @dots{} @}
 >> \oneVoice
 @end example
 
@@ -494,7 +495,7 @@ warning: ignoring too many clashing note columns
 
 @subsubsubheading 2 重バックスラッシュ構造
 
-@code{<< @{...@} \\ @{...@} >>} 構造
+@code{<< @{@dots{}@} \\ @{@dots{}@} >>} 構造
 -- この中では 2 つ (あるいはそれ以上) の表記が
 2 重バックスラッシュで区切られています --
 は、同じような構造だが 2 重バックスラッシュを持たない構造とは@c
@@ -569,11 +570,33 @@ etc.
   \\
   { e'2  }  % 4: 下から 2 番
   \\
-  { b'2  }  % 5: 上から 2 番
+  { b'2  }  % 5: 上から 3 番
   \\
   { g'2  }  % 6: 下から 3 番
 >>
 @end lilypond
+
+@funindex \voices
+ボイスの入力順序を変更したい場合、@code{\voices} コマンドが役に立ちます:
+
+@c KEEP LY
+@lilypond[quote,verbatim]
+\new Staff \voices 1,3,5,6,4,2 <<
+  \time 2/4
+  { f''2 }  % 1: 最上段
+  \\
+  { d''2 }  % 3: 上から 2 番
+  \\
+  { b'2  }  % 5: 上から 3 番
+  \\
+  { g'2  }  % 6: 下から 3 番
+  \\
+  { e'2  }  % 4: 下から 2 番
+  \\
+  { c'2  }  % 2: 最下段
+>>
+@end lilypond
+
 
 @warning{歌詞、スパナ (スラー、タイ、強弱のヘアピン等) はボイスを @q{跨ぐ}
 ことはできません。}
@@ -674,7 +697,7 @@ etc.
 @cindex note collisions (音符の衝突)
 @cindex collisions (衝突)
 @cindex shift note (音符のシフト)
-@cindex multiple voices
+@cindex multiple voices (複数のボイス)
 @cindex voices, multiple (複数のボイス)
 @cindex polyphonic music (多声の音楽)
 @cindex shifting voices (ボイスをずらす)
@@ -715,9 +738,8 @@ etc.
 >>
 @end lilypond
 
-以下に示すように、異なる符頭を持つ音符をマージすることができます
--- 例外として、半音符と 4 分音符のマージはできません。@c
-第 1 小節の 1 拍目の符頭がマージされました:
+以下に示すように、異なる符頭を持つ音符をマージすることができます。@c
+この例では、第 1 小節の 1 拍目の符頭がマージされました:
 
 @lilypond[quote,verbatim]
 <<
@@ -737,6 +759,9 @@ etc.
   }
 >>
 @end lilypond
+
+四分音符と二分音符はこの方法ではマージされません。@c
+なぜなら区別が難しくなるからです。
 
 第 1 小節の 3 拍目のように異なる付点を持つ符頭もマージすることができます:
 
@@ -894,22 +919,45 @@ etc.
 
 @ignore
 @knownissues
-上向きの符幹を持つ 8 分音符やそれよりも短い音符と下向きの符幹を持つ@c
-半音符に対して @code{\mergeDifferentlyHeadedOn} を使用した場合、@c
-8 分音符の符幹のオフセットはわずかに正しくなりません。@c
-なぜなら、半音符の符頭シンボルと幅が異なるからです。
-
 @c TODO investigate! Sometimes it works, sometimes not. --FV
 The requirements for successfully merging different note heads that
 are at the same time differently dotted are not clear.
-
-同じ和音の中で同じ音符が異なる臨時記号を持つ場合、その和音の衝突回避は@c
-サポートされません。@c
-そのような場合、異名同音 (エンハーモニック) に書き換えるか、@c
-クラスタという特殊な記譜法 (@ref{クラスタ} を参照してください)
-を用いることを推奨します。
 @end ignore
 
+
+@node 休符のマージ
+@unnumberedsubsubsec 休符のマージ
+@translationof Merging rests
+
+複数のボイスを用いる場合、両方のパートに出現する休符はマージされるのが@c
+一般的です。これは @code{Merge_rests_engraver} を用いることで達成できます。
+
+@lilypond[quote,verbatim]
+voiceA = \relative { d''4 r d2 | R1 | }
+voiceB = \relative { fis'4 r g2 | R1 | }
+\score {
+  <<
+    \new Staff \with {
+      instrumentName = "unmerged"
+    }
+    <<
+      \new Voice { \voiceOne \voiceA }
+      \new Voice { \voiceTwo \voiceB }
+    >>
+    \new Staff \with {
+      instrumentName = "merged"
+      \consists #Merge_rests_engraver
+    }
+    <<
+      \new Voice { \voiceOne \voiceA }
+      \new Voice { \voiceTwo \voiceB }
+    >>
+  >>
+}
+@end lilypond
+
+@code{suspendRestMerging} コンテキスト プロパティを @code{##t} に@c
+セットすることで、休符のマージを一時的に無効にすることができます。
 
 @node 自動パート結合
 @unnumberedsubsubsec 自動パート結合
@@ -978,6 +1026,35 @@ instrumentTwo = \relative {
 斉奏 (@notation{二重奏}) パートには、デフォルトで、テキスト @qq{a2} という@c
 マークが付けられます。
 
+デフォルトでは、@code{\partcombine} は同じピッチの音符を @notation{二重奏} の@c
+音符としてマージします。また、同じリズムで音程が 9 度以下の音符は和音として@c
+結合し、9 度より大きい (あるいは、ボイスが交差している) 場合は別々のボイスに@c
+なります。この挙動は @code{\partcombine} コマンドの後に、省略可能な@c
+数字のペアの引数を与えることでオーバライドすることができます:
+1 つ目が、結合が始まる音程 (デフォルトは 0) で、@c
+2 つ目が別々のボイスとなる音程です。@c
+2 つ目の引数を 0 にすることで、2 度以上の音符を分割し、@c
+1 にすることで 3 度以上の音符を分割するというようになります。
+
+@lilypond[quote,verbatim]
+instrumentOne = \relative {
+  a4 b c d |
+  e f g a |
+  b c d e |
+}
+
+instrumentTwo = \relative {
+  c'4 c c c |
+  c c c c |
+  c c c c |
+}
+
+<<
+  \new Staff \partcombine \instrumentOne \instrumentTwo
+  \new Staff \partcombine #'(2 . 3) \instrumentOne \instrumentTwo
+>>
+@end lilypond
+
 @code{\partcombine} の 2 つの引数は別個の @code{Voice} コンテキストとして@c
 解釈されます。@c
 そのため、相対オクターブを用いる場合、両方のパートで @code{\relative} を@c
@@ -1007,35 +1084,34 @@ instrumentTwo = \relative {
 ですから、音符を和音に組み合わせることと、1 つのボイスをソロとして表示すること@c
 は等価ではありません。@c
 なぜなら、@code{\partcombine} 関数は各音符を個々に考慮するからです。
-このような場合、@code{\partcombine} 関数を以下のコマンドで@c
-オーバライドすることができます:
-
-@code{...Once} で終わるコマンドは、コマンドの次に来る音符だけに適用されます。
+このような場合、@code{\partcombine} 関数を以下のコマンドのいずれかで@c
+オーバライドすることができます。全てのコマンドは音楽表記の中で@c
+次の音符だけに適用されるように @code{\once} 接頭辞を付けることができます。
 
 @itemize
 @item
-@code{\partcombineApart} と @code{\once \partcombineApart} は@c
+@code{\partcombineApart} は@c
 音符を 2 つの別個のボイスとして譜刻します
 -- たとえ和音やユニゾンにできる場合であっても分けて譜刻します。
 
 @item
-@code{\partcombineChords} と @code{\once \partcombineChords} は@c
+@code{\partcombineChords} は@c
 音符を組み合わせて、和音として譜刻します。
 
 @item
-@code{\partcombineUnisono} と @code{\once \partcombineUnisono} は@c
+@code{\partcombineUnisono} は@c
 音符を組み合わせて、@qq{ユニゾン} として譜刻します。
 
 @item
-@code{\partcombineSoloI} と @code{\once \partcombineSoloI} は@c
+@code{\partcombineSoloI} は@c
 ボイス 1 だけを譜刻して、@qq{Solo} のマークを付けます。
 
 @item
-@code{\partcombineSoloII} と @code{\once \partcombineSoloII} は@c
+@code{\partcombineSoloII} は@c
 ボイス 2 だけを譜刻して、@qq{Solo} のマークを付けます。
 
 @item
-@code{\partcombineAutomatic} と @code{\once \partcombineAutomatic}は@c
+@code{\partcombineAutomatic} は@c
 上記のコマンドの効果を終わらせ、標準の @code{\partcombine} に戻します。
 @end itemize
 
@@ -1064,6 +1140,18 @@ instrumentTwo = \relative {
 >>
 @end lilypond
 
+
+@subsubsubheading \partcombine を歌詞と同時に使う
+
+@cindex \partcombine and lyrics (\partcombine と歌詞)
+
+@code{\partcombine} は歌詞と同時に動作するように設計されていません。@c
+歌詞を付けるために、ボイスの片方に名前が明示されていた場合、パート結合は@c
+動作を停止します。しかし、@code{NullVoice} コンテキストを用いることで@c
+効果を得ることができます。@ref{Polyphony with shared lyrics} を@c
+参照してください。
+
+
 @snippets
 
 @lilypondfile[verbatim,quote,texidoc,doctitle]
@@ -1088,11 +1176,9 @@ instrumentTwo = \relative {
 @rinternals{Voice}
 
 @knownissues
-すべての @code{\partcombine...} はボイスを 2 つだけ受け取ることができ、@c
-歌詞を処理するようには設計されていません。@c
-ボイスに歌詞が付けられている場合、パート結合は処理を停止します。
+すべての @code{\partcombine@dots{}} はボイスを 2 つだけ受け取ることができます。
 
-@code{\partcombine...} 関数を @code{\tuplet} ブロックや @code{\relative}
+@code{\partcombine@dots{}} 関数を @code{\tuplet} ブロックや @code{\relative}
 ブロックの中に置くことはできません。
 
 @code{printPartCombineTexts} がセットされていて、ある小節で 2 つのボイスの@c

--- a/Documentation/ja/notation/staff.itely
+++ b/Documentation/ja/notation/staff.itely
@@ -1,6 +1,6 @@
 @c -*- coding: utf-8; mode: texinfo; documentlanguage: ja -*-
 @ignore
-    Translation of GIT committish: fabcd22c8f88ea9a87241597f1e48c0a9adbfc6e
+    Translation of GIT committish: eb38c33a95cbe6adf9f176dfbb794373ec062605
 
     When revising a translation, copy the HEAD committish of the
     version that you are working on.  See TRANSLATION for details.
@@ -9,7 +9,7 @@
 @c \version "2.19.21"
 
 
-@c Translators: Yoshiki Sawada
+@c Translators: Tomohiro Tatejima, Yoshiki Sawada
 @c Translation status: post-GDP
 
 
@@ -42,7 +42,7 @@
 * 新たに譜をインスタンス化する::
 * 譜をグループ化する::
 * ネストされた譜グループ::
-* Separating systems::
+* システムを分割する::
 @end menu
 
 
@@ -222,8 +222,8 @@
 詳細は @ref{Instrument names} を参照してください。
 
 @lilypond[verbatim,quote]
-\new PianoStaff <<
-  \set PianoStaff.instrumentName = #"Piano"
+\new PianoStaff \with { instrumentName = #"Piano" }
+<<
   \new Staff \relative { c''1 c }
   \new Staff \relative { \clef bass c1 c }
 >>
@@ -248,11 +248,10 @@
 @lilypondfile[verbatim,quote,texidoc,doctitle]
 {display-bracket-with-only-one-staff-in-a-system.ly}
 
-@c 未訳
-@cindex mensurstriche layout
-@cindex renaissance music)
-@cindex transcription of mensural music
-@cindex mensural music, transcription of
+@cindex mensurstriche layout (計量音楽風のレイアウト)
+@cindex renaissance music (ルネサンス音楽)
+@cindex transcription of mensural music (計量音楽の編曲)
+@cindex mensural music, transcription of (計量音楽の編曲)
 
 @lilypondfile[verbatim,quote,texidoc,doctitle]
 {mensurstriche-layout-bar-lines-between-the-staves.ly}
@@ -281,9 +280,6 @@
 @rinternals{SystemStartBracket},
 @rinternals{SystemStartSquare}
 
-@knownissues
-デフォルトでは @code{PianoStaff} は @code{ChordNames} を受け付けません。
-
 
 @node ネストされた譜グループ
 @unnumberedsubsubsec ネストされた譜グループ
@@ -301,17 +297,17 @@
 そうした場合、それぞれの子コンテキストは、@c
 親グループの角括弧に隣接して新しい角括弧を作成します。
 
-@lilypond[verbatim,quote,relative=2]@lilypond[verbatim,quote,relative=2]
+@lilypond[verbatim,quote]
 \new StaffGroup <<
-  \new Staff { c2 c | c2 c }
+  \new Staff \relative { c''2 c | c2 c }
   \new StaffGroup <<
-    \new Staff { g2 g | g2 g }
+    \new Staff \relative { g'2 g | g2 g }
     \new StaffGroup \with {
       systemStartDelimiter = #'SystemStartSquare
     }
     <<
-      \new Staff { e2 e | e2 e }
-      \new Staff { c2 c | c2 c }
+      \new Staff \relative { e'2 e | e2 e }
+      \new Staff \relative { c'2 c | c2 c }
     >>
   >>
 >>
@@ -344,19 +340,20 @@
 @rinternals{SystemStartSquare}
 
 
-@c 未訳
-@node Separating systems
-@unnumberedsubsubsec Separating systems
+@node システムを分割する
+@unnumberedsubsubsec システムを分割する
+@translationof Separating systems
 
-@cindex system separator mark
+@cindex system separator mark (システム分割記号)
 
-If the number of systems per page changes from page to page it is
-customary to separate the systems by placing a system separator mark
-between them.  By default the system separator is blank, but can be
-turned on with a @code{\paper} option.
+1 ページあたりのシステムの数がページによって異なる場合、@c
+システム分割記号を間に置くことでシステムを分割するという慣習があります。@c
+デフォルトでは、システム分割記号は空になっていますが、
+@code{\paper} オプションで有効にすることができます。
 
 @c \book is required here to display the system separator
 @c ragged-right is required as there are two systems
+@c KEEP LY
 @lilypond[verbatim,quote,ragged-right]
 \book {
   \score {
@@ -379,7 +376,7 @@ turned on with a @code{\paper} option.
   }
   \paper {
     system-separator-markup = \slashSeparator
-    % following commands are needed only to format this documentation
+    % 以下のコマンドはこのドキュメントでの体裁を整えるためだけのものです
     paper-width = 100\mm
     paper-height = 100\mm
     tagline = ##f
@@ -392,7 +389,7 @@ turned on with a @code{\paper} option.
 @ref{Page layout}
 
 コード断片集:
-@rlsr{Staff notation}.
+@rlsr{Staff notation}
 
 
 @node 個々の譜を変更する
@@ -440,7 +437,7 @@ turned on with a @code{\paper} option.
 @code{\stopStaff}
 @endpredefined
 
-@code{StaffSymbol} グラフィカル オブジェクト (加線を含む) に属する譜の線は@c
+譜の線 (加線を含む) は @code{StaffSymbol} グラフィカル オブジェクトに属し、
 @code{StaffSymbol} プロパティを用いて変更することができます。@c
 しかしながら、変更は譜が (再) 開始する前に行う必要があります。
 
@@ -459,8 +456,9 @@ turned on with a @code{\paper} option.
 @end lilypond
 
 各譜線の位置を変更することもできます。@c
-値の単位は譜線の間隔の @emph{半分} で、@c
-新しい位置は通常の中央線からの相対位置です。@c
+数字のリストでそれぞれの譜線の位置を指定します。@c
+@code{0}@tie{}は通常の譜における中央の線で、@c
+通常の譜の譜線の位置は @code{(-4@tie{}-2@tie{}0@tie{}2@tie{}4)} となります。
 1 つの値に対して 1 本の譜線が譜刻されるので、@c
 1 つのオーバライドで譜線の位置と本数を変更することができます。
 
@@ -475,8 +473,11 @@ turned on with a @code{\paper} option.
 }
 @end lilypond
 
+符幹の向きが通常通り (譜の下半分では上向き、上半分では下向き) になるように、@c
+カスタマイズした譜では中央の線 (あるいは「間」) を通常の中央の位置 (0) に@c
+配置するようにしてください。
 新しい譜線に対応して、@c
-音部記号とミドル C の位置を調節する必要があるかもしれません。@c
+音部記号とミドル@tie{}C の位置を調節する必要があるかもしれません。@c
 @ref{Clef} を参照してください。
 
 譜線の太さを変えることができます。@c
@@ -491,9 +492,7 @@ turned on with a @code{\paper} option.
 }
 @end lilypond
 
-しかしながら、加線の太さを譜線の太さから独立して設定することができます。@c
-2 つの値は譜線の太さと譜線の間隔に掛け算され、@c
-それらを加算した値が加線の太さになります。
+加線の太さを譜線の太さから独立して設定することもできます。
 
 @lilypond[verbatim,quote]
 \new Staff \with {
@@ -503,6 +502,10 @@ turned on with a @code{\paper} option.
   f'''4 a, a,, f
 }
 @end lilypond
+
+@noindent
+1 つ目の値は譜線の太さに、2 つ目は譜線の間隔に掛け算され、@c
+それら 2 つの値を加算した値が加線の太さになります。
 
 加線の垂直方向の位置を変更することができます:
 
@@ -532,13 +535,15 @@ turned on with a @code{\paper} option.
 以下の例で、@code{StaffSymbol} 全体に対する @code{\override} を元に戻すには@c
 @code{\stopStaff} を行う必要があります。
 
-@lilypond[fragment,quote,relative=1]
-\override Staff.StaffSymbol.line-positions =   #'(-8 0 2 4)
-d4 e f g
-\stopStaff
-\startStaff
-\override Staff.StaffSymbol.ledger-positions = #'(-8 -6 (-4 -2) 0)
-d4 e f g
+@lilypond[verbatim,quote]
+\relative d' {
+  \override Staff.StaffSymbol.line-positions = #'(-8 0 2 4)
+  d4 e f g
+  \stopStaff
+  \startStaff
+  \override Staff.StaffSymbol.ledger-positions = #'(-8 -6 (-4 -2) 0)
+  d4 e f g
+}
 @end lilypond
 
 譜線の間隔を変えることができます。この設定は加線の間隔にも影響を与えます。
@@ -576,11 +581,9 @@ d4 e f g
 @unnumberedsubsubsec オッシア譜
 @translationof Ossia staves
 
-@c 未訳
-@cindex staff, Frenched
+@cindex staff, Frenched (隠された譜)
 @cindex ossia (オッシア)
-@c 未訳
-@cindex Frenched staves
+@cindex Frenched staves (隠された譜)
 @cindex staff, resizing of (譜をリサイズする)
 @cindex resizing of staves (譜をリサイズする)
 
@@ -614,7 +617,7 @@ d4 e f g
 最も適切な方法です。
 
 @lilypond[verbatim,quote]
-\new Staff = main \relative {
+\new Staff = "main" \relative {
   c''4 b d c
   <<
     { c4 b d c }
@@ -622,9 +625,7 @@ d4 e f g
     \new Staff \with {
       \remove "Time_signature_engraver"
       alignAboveContext = #"main"
-      fontSize = #-3
-      \override StaffSymbol.staff-space = #(magstep -3)
-      \override StaffSymbol.thickness = #(magstep -3)
+      \magnifyStaff #2/3
       firstClef = ##f
     }
     { e4 d f e }
@@ -643,12 +644,10 @@ d4 e f g
 
 @lilypond[verbatim,quote,ragged-right]
 <<
-  \new Staff = ossia \with {
+  \new Staff = "ossia" \with {
     \remove "Time_signature_engraver"
     \hide Clef
-    fontSize = #-3
-    \override StaffSymbol.staff-space = #(magstep -3)
-    \override StaffSymbol.thickness = #(magstep -3)
+    \magnifyStaff #2/3
   }
   { \stopStaff s1*6 }
 
@@ -656,7 +655,7 @@ d4 e f g
     c'4 b c2
     <<
       { e4 f e2 }
-      \context Staff = ossia {
+      \context Staff = "ossia" {
         \startStaff e4 g8 f e2 \stopStaff
       }
     >>
@@ -664,7 +663,7 @@ d4 e f g
     c4 b c2
     <<
       { g4 a g2 }
-      \context Staff = ossia {
+      \context Staff = "ossia" {
         \startStaff g4 e8 f g2 \stopStaff
       }
     >>
@@ -674,21 +673,20 @@ d4 e f g
 @end lilypond
 
 オッシア譜を作成するための代替手段として、@c
-@code{\RemoveEmptyStaffContext} コマンドが用いられるかもしれません。@c
+@code{\RemoveAllEmptyStaves} コマンドが用いられるかもしれません。@c
 この手法は、オッシア譜が改行の直後に発生する場合、最も便利な手法です。@c
 @c そのようなケースでは、空白休符を使用する必要はまったくありません:
 @c @code{\startStaff} と @code{\stopStaff} が必要であるだけです。@c
-@code{\RemoveEmptyStaffContext} についての更なる情報は、@c
+@code{\RemoveAllEmptyStaves} についての更なる情報は、@c
 @ref{Hiding staves} を参照してください。
 
 @lilypond[verbatim,quote,ragged-right]
 <<
-  \new Staff = ossia \with {
+  \new Staff = "ossia" \with {
     \remove "Time_signature_engraver"
     \hide Clef
-    fontSize = #-3
-    \override StaffSymbol.staff-space = #(magstep -3)
-    \override StaffSymbol.thickness = #(magstep -3)
+    \magnifyStaff #2/3
+    \RemoveAllEmptyStaves
   } \relative {
     R1*3
     c''4 e8 d c2
@@ -702,13 +700,6 @@ d4 e f g
     e4 d c2
   }
 >>
-
-\layout {
-  \context {
-    \Staff \RemoveEmptyStaves
-    \override VerticalAxisGroup.remove-first = ##t
-  }
-}
 @end lilypond
 
 
@@ -742,16 +733,18 @@ d4 e f g
 @unnumberedsubsubsec 譜を隠す
 @translationof Hiding staves
 
-@c 未訳
-@cindex Frenched score
-@c 未訳
-@cindex Frenched staff
+@cindex Frenched score (譜が隠された楽譜)
+@cindex Frenched staff (隠された譜)
 @cindex staff, hiding (譜を隠す)
 @cindex staff, empty (空の譜)
-@cindex hiding of staves (譜を隠す)
+@cindex hiding staves (譜を隠す)
+@cindex hiding ancient staves (古代譜を隠す)
+@cindex hiding rhythmic staves (リズム譜を隠す)
+@cindex hiding vaticana staves (バチカン譜を隠す)
 @cindex empty staves (空の譜)
 
 @funindex \RemoveEmptyStaves
+@funindex \RemoveAllEmptyStaves
 @funindex Staff_symbol_engraver
 @funindex \stopStaff
 
@@ -766,14 +759,17 @@ d4 e f g
 \relative { a''8 f e16 d c b a2 }
 @end lilypond
 
-@c 未訳: Frenched Score
-@code{\layout} ブロックの中で
-@code{\RemoveEmptyStaffContext} コマンドをセットすることによって、@c
-空の譜を隠すことができます。@c
-オーケストラ譜では、@c
-このようなスタイルの譜は @q{Frenched Score} として知られています。@c
-デフォルトでは、このコマンドは@c
-最初のシステム以外のところにあるすべての空の譜を隠して、削除します。
+@c Frenched Score
+@c 適当な訳語が見つからないため、原文のままとし、
+@c index中では「隠された譜」などとした
+空の譜は隠すことができます (いわゆる @q{Frenched Score} にするため)。@c
+これは、コンテキスト中で @code{\RemoveEmptyStaves} を適用することで@c
+実現できます。(@code{\layout} ブロック内に適用することによって) 楽譜全体に@c
+設定することも、(@code{\with} ブロック内に適用することによって) 特定の譜に@c
+限定することもできます。このコマンドは、最初のシステムを除いて、@c
+楽譜内にある全ての空の譜を削除します。最初のシステムにある譜も隠したい場合は、@c
+@code{\RemoveAllEmptyStaves} を使ってください。サポートしているコンテキストは
+@code{Staff}, @code{RhythmicStaff}, @code{VaticanaStaff} です。
 
 @warning{譜が空であると見なされるのは、@c
 それが複数小節にわたる休符、休符、スキップ、空白休符、@c
@@ -782,7 +778,8 @@ d4 e f g
 @lilypond[verbatim,quote,ragged-right]
 \layout {
   \context {
-    \Staff \RemoveEmptyStaves
+    \Staff
+    \RemoveEmptyStaves
   }
 }
 
@@ -804,31 +801,13 @@ d4 e f g
 
 @noindent
 譜に対してオッシア セクションを作成するために、@c
-@code{\RemoveEmptyStaffContext} を用いることもできます。@c
+@code{\RemoveAllEmptyStaves} を用いることもできます。@c
 詳細は @ref{Ossia staves} を参照してください。
 
-@cindex hiding ancient staves (古代譜を隠す)
-@cindex hiding rhythmic staves (リズム譜を隠す)
-
-@funindex \RemoveEmptyStaves
-
-古代音楽コンテキストの中にある空の譜を隠すために、@c
-@code{\VaticanaStaff \RemoveEmptyStaves} コマンドが用いられることがあります。@c
-同様に、空の @code{RhythmicStaff} コンテキストを隠すために、@c
-@code{\RhythmicStaff \RemoveEmptyStaves} が用いられることがあります。
-
-
 @predefined
-@code{\Staff \RemoveEmptyStaves},
-@code{\VaticanaStaff \RemoveEmptyStaves},
-@code{\RhythmicStaff \RemoveEmptyStaves}
+@code{\RemoveEmptyStaves},
+@code{\RemoveAllEmptyStaves}
 @endpredefined
-
-
-@snippets
-
-@lilypondfile[verbatim,quote,texidoc,doctitle]
-{removing-the-first-empty-line.ly}
 
 @seealso
 音楽用語集:
@@ -991,60 +970,42 @@ d4 e f g
 @cindex instrument names, changing (楽器名を変更する)
 @cindex changing instrument names (楽器名を変更する)
 
-楽曲の途中で @code{shortInstrumentName} を変更することもできます。@c
+楽曲の途中で @code{shortInstrumentName} や、新しい楽器に必要なその他の設定を@c
+変更することもできます。@c
 しかしながら、@code{instrumentName} は最初のインスタンスが譜刻され、@c
 楽曲の途中での変更は無視されます:
 
-@lilypond[verbatim,quote,ragged-right,relative=1]
+@lilypond[verbatim,quote,ragged-right]
+prepPiccolo = <>^\markup \italic { muta in Piccolo }
+
+prepFlute = <>^\markup \italic { muta in Flauto }
+
+setPiccolo = {
+  <>^\markup \bold { Piccolo }
+  \transposition c''
+}
+
+setFlute = {
+  <>^\markup \bold { Flute }
+  \transposition c'
+}
+
 \new Staff \with {
   instrumentName = #"Flute"
   shortInstrumentName = #"Flt."
 }
-{
-  c1 c c c \break
-  c1 c c c \break
-  \set Staff.instrumentName = #"Clarinet"
-  \set Staff.shortInstrumentName = #"Clt."
-  c1 c c c \break
-  c1 c c c \break
-}
-@end lilypond
-
-@cindex instrument switch (楽器を切り換える)
-@cindex switching instruments (楽器を切り換える)
-
-@funindex \addInstrumentDefinition
-@funindex \instrumentSwitch
-
-楽器の @emph{切り替え} が必要な場合、切り替えのために必要とされる@c
-変更の詳細なリストを作成するために、@code{\addInstrumentDefinition} を
-@code{\instrumentSwitch} と組み合わせて使用することがあります。@c
-@code{\addInstrumentDefinition} コマンドは 2 つの引数をとります:
-識別文字列と、楽器で使用されるコンテキスト プロパティと値の連想リストです。@c
-このコマンドは最上位のスコープに配置する必要があります。@c
-@code{\instrumentSwitch} は音楽表記の中で使用され、楽器の切り替えを宣言します:
-
-@lilypond[verbatim,quote,ragged-right]
-\addInstrumentDefinition #"contrabassoon"
-  #`((instrumentTransposition . ,(ly:make-pitch -1 0 0))
-     (shortInstrumentName . "Cbsn.")
-     (clefGlyph . "clefs.F")
-     (middleCPosition . 6)
-     (clefPosition . 2)
-     (instrumentCueName . ,(make-bold-markup "cbsn."))
-     (midiInstrument . "bassoon"))
-
-\new Staff \with {
-  instrumentName = #"Bassoon"
-}
-\relative c' {
-  \clef tenor
-  \compressFullBarRests
-  c2 g'
-  R1*16
-  \instrumentSwitch "contrabassoon"
-  c,,2 g \break
-  c,1 ~ | 1
+\relative {
+  g'1 g g g \break
+  g1 g \prepPiccolo R R \break
+  \set Staff.instrumentName = #"Piccolo"
+  \set Staff.shortInstrumentName = #"Picc."
+  \setPiccolo
+  g1 g g g \break
+  g1 g \prepFlute R R \break
+  \set Staff.instrumentName = #"Flute"
+  \set Staff.shortInstrumentName = #"Flt."
+  \setFlute
+  g1 g g g
 }
 @end lilypond
 
@@ -1132,6 +1093,40 @@ oboeNotes = \relative {
 }
 @end lilypond
 
+@code{\unfoldRepeats} コマンドを @code{\quoteDuring} と一緒に使う場合、@c
+引用の中でも @code{\unfoldRepeats} コマンドを使わなければなりません:
+
+@lilypond[verbatim,quote]
+fluteNotes = \relative {
+  \repeat volta 2 { a'4 gis g gis }
+}
+
+oboeNotesDW = \relative {
+  \repeat volta 2 \quoteDuring #"incorrect" { s1 }
+}
+
+oboeNotesW = \relative {
+  \repeat volta 2 \quoteDuring #"correct" { s1 }
+}
+
+
+\addQuote "incorrect" { \fluteNotes }
+
+\addQuote "correct" { \unfoldRepeats \fluteNotes }
+
+\score {
+  \unfoldRepeats
+  <<
+    \new Staff \with { instrumentName = "Flute" }
+    \fluteNotes
+    \new Staff \with { instrumentName = "Oboe (incorrect)" }
+    \oboeNotesDW
+    \new Staff \with { instrumentName = "Oboe (correct)" }
+    \oboeNotesW
+  >>
+}
+@end lilypond
+
 @code{\quoteDuring} コマンドは引用されるパートと引用するパート両方の
 @code{\transposition} を使用して、@c
 引用されるパートと同じ響きのピッチに変換して、@c
@@ -1163,6 +1158,8 @@ oboeNotes = \relative {
 @cindex articulation-event
 @cindex dynamic-event
 @cindex rest-event
+@cindex slur-event
+@cindex crescendo-event
 
 @funindex quotedEventTypes
 @funindex quotedCueEventTypes
@@ -1203,6 +1200,9 @@ oboeNotes = \relative {
 記譜法リファレンス:
 @ref{Instrument transpositions},
 @ref{Using tags}
+
+インストールされているファイル:
+@file{scm/define-event-classes.scm}.
 
 コード断片集:
 @rlsr{Staff notation}
@@ -1315,17 +1315,9 @@ LilyPond がクラッシュする可能性さえあります。
 @code{CueVoice} コンテキストとして追加されて
 @code{@var{music}} と同時進行して、@c
 多声になります。@c
-@code{@var{direction}} は引数 @code{UP} または @code{DOWN} を取り、@c
-それぞれ第 1 及び第 2 ボイスと調和して、@c
+@code{@var{direction}} は引数 @code{UP} または @code{DOWN} を取り
+-- それぞれ第 1 ボイス及び第 2 ボイスと対応します --
 合図音符が他のボイスに対してどのように譜刻されるかを決定します。
-
-このコマンドは @code{@var{partname}} の該当する小節から音符と休符だけを
-@code{CueVoice} にコピーします。@c
-@code{CueVoice} は暗黙的に作成されて @code{@var{music}} と同時進行し、@c
-結果として多声になります。@c
-引数 @code{@var{voice}} は合図音符を第 1 ボイスとして記譜すべきか、@c
-第 2 ボイスとして記譜すべきかを決定します。@c
-@code{UP} は第 1 ボイスに相当し、@code{DOWN} は第 2 ボイスに相当します。
 
 @lilypond[verbatim,quote]
 fluteNotes = \relative {
@@ -1334,7 +1326,7 @@ fluteNotes = \relative {
 
 oboeNotes = \relative c'' {
   R1
-  \new CueVoice { \set instrumentCueName = "flute" }
+  <>^\markup \tiny { flute }
   \cueDuring #"flute" #UP { R1 }
   g2 c,
 }
@@ -1346,10 +1338,11 @@ oboeNotes = \relative c'' {
 }
 @end lilypond
 
+
 @noindent
 
 @code{instrumentCueName} プロパティを設定することによって、@c
-@code{\cueDuring} で音楽のどの側面を引用するか調節することができます。@c
+@code{\cueDuring} で音楽のどの部分を引用するか調節することができます。@c
 このプロパティのデフォルト値は @code{'(note-event rest-event
 tie-event beam-event tuplet-span-event)} であり、音符、休符、タイ、連桁、@c
 それに連符だけが引用され、アーティキュレーション、強弱記号、マークアップ等は@c
@@ -1375,13 +1368,7 @@ oboeNotes = \relative {
 }
 @end lilypond
 
-@c ここから L2334
-一時的な @code{CueVoice} コンテキストの中の @code{instrumentCueName}
-プロパティを設定することで、合図を演奏する楽器の名前を表示させることが@c
-できます。@c
-@code{instrumentCueName} の位置とスタイルは @code{\instrumentSwitch}
-オブジェクトによって制御されます -- @ref{Instrument names} を参照して@c
-ください。@c
+引用される楽器の名前を表示するために、マークアップを用いることができます。@c
 合図音符が音符記号の変更を必要とする場合、手動で変更することができますが、@c
 合図音符が終わったところで手動で元の音部記号に戻す必要がありｍす。
 
@@ -1394,7 +1381,7 @@ bassoonNotes = \relative c {
   \clef bass
   R1
   \clef treble
-  \new CueVoice { \set instrumentCueName = "flute" }
+  <>^\markup \tiny { flute }
   \cueDuring #"flute" #UP { R1 }
   \clef bass
   g4. b8 d2
@@ -1420,7 +1407,7 @@ fluteNotes = \relative {
 bassoonNotes = \relative c {
   \clef bass
   R1
-  \new CueVoice { \set instrumentCueName = "flute" }
+  <>^\markup { \tiny "flute" }
   \cueDuringWithClef #"flute" #UP #"treble" { R1 }
   g4. b8 d2
 }
@@ -1471,7 +1458,6 @@ bassClarinetNotes = \relative c' {
 @cindex cue notes, removing (合図音符を削除する)
 
 @funindex \killCues
-@funindex \addInstrumentDefinition
 
 @code{\killCues} コマンドは音楽表記から合図音符を削除します。@c
 これにより、同じ音楽表記を使って合図を持つ楽器パートと楽譜を作り出すことが@c
@@ -1493,7 +1479,7 @@ bassoonNotes = \relative c {
   R1
   \tag #'part {
     \clef treble
-  \new CueVoice { \set instrumentCueName = "flute" }
+    <>^\markup \tiny { flute }
   }
   \cueDuring #"flute" #UP { R1 }
   \tag #'part \clef bass

--- a/Documentation/ja/notation/text.itely
+++ b/Documentation/ja/notation/text.itely
@@ -1,7 +1,7 @@
 @c -*- coding: utf-8; mode: texinfo; documentlanguage: ja -*-
 
 @ignore
-    Translation of GIT committish: 76ee88f5adfc7bcd8eff487543e3605e43a93d80
+    Translation of GIT committish: eb38c33a95cbe6adf9f176dfbb794373ec062605
 
     When revising a translation, copy the HEAD committish of the
     version that you are working on.  For details, see the Contributors'
@@ -11,7 +11,7 @@
 @c \version "2.19.21"
 
 
-@c Translators: Masamichi Hosoda, Yoshiki Sawada
+@c Translators: Tomohiro Tatejima, Masamichi Hosoda, Yoshiki Sawada
 @c Translation status: post-GDP
 
 
@@ -247,9 +247,12 @@ LilyPond が処理できるテキスト スパナは 1 ボイスにつき、1 �
 
 @lilypond[verbatim,quote]
 \relative {
-  c''4
-  \mark "Allegro"
-  c c c
+  \mark "Verse"
+  c'2 g'
+  \bar "||"
+  \mark "Chorus"
+  g2 c,
+  \bar "|."
 }
 @end lilypond
 
@@ -534,7 +537,7 @@ allegro = \markup { \bold \large Allegro }
 @rlsr{Text}
 
 @knownissues
-マークアップ モードの構文エラーは混乱しやすいです。
+マークアップ モードの構文エラー メッセージは混乱しやすいです。
 
 
 @node フォントとフォント サイズを選択する
@@ -572,7 +575,7 @@ allegro = \markup { \bold \large Allegro }
 @funindex \larger
 @funindex \magnify
 
-フォント サイズをいくつかの方法でグローバル譜サイズとの相対値で変更することができます。
+フォント サイズをグローバル譜サイズとの相対値で変更する方法はいくつかあります。
 
 フォント サイズをあらかじめ定義されているサイズに設定することができます:
 
@@ -594,8 +597,8 @@ allegro = \markup { \bold \large Allegro }
 }
 @end lilypond
 
-フォント サイズをグローバル譜サイズによって設定されている値で拡大あるいは縮小させる@c
-ことができます:
+フォント サイズをグローバル譜サイズによって設定されている値で拡大あるいは@c
+縮小させることができます:
 
 @lilypond[quote,verbatim]
 \relative b' {
@@ -605,8 +608,8 @@ allegro = \markup { \bold \large Allegro }
 }
 @end lilypond
 
-さらに、フォント サイズをグローバル譜サイズとは無関係に、固定ポイント サイズに設定する@c
-ことができます:
+さらに、フォント サイズをグローバル譜サイズとは無関係に、固定ポイント サイズに@c
+設定することができます:
 
 @lilypond[quote,verbatim]
 \relative b' {
@@ -801,7 +804,7 @@ allegro = \markup { \bold \large Allegro }
 @end lilypond
 
 @noindent
-オブジェクトの中には揃えるためのプロシージャをそれ自身で持っているものがあり、@c
+オブジェクトの中には揃えるための機能をそれ自身で持っているものがあり、@c
 それらは上記のコマンドでは影響を受けません。@c
 @ref{テキスト マーク} の中の例で示されているように、@c
 そのようなマークアップ オブジェクト全体を移動させることが可能です。
@@ -1150,7 +1153,7 @@ c'
 @seealso
 記譜法リファレンス:
 @ref{Align},
-Dimensions,
+@ref{Dimensions},
 @ref{編集者の注釈},
 @ref{Graphic}
 
@@ -1356,11 +1359,11 @@ a'1_\markup {
 拡張:
 @rextend{New markup list command definition}
 
-インストールされているファイル:
-@file{scm/define-markup-commands.scm}
-
 コード断片集:
 @rlsr{Text}
+
+インストールされているファイル:
+@file{scm/define-markup-commands.scm}
 
 内部リファレンス:
 @rinternals{TextScript}
@@ -1403,7 +1406,7 @@ FontConfig はシステムで利用可能なフォントを検出するために
 音楽記譜フォントはいくつかのファミリに分類された特殊な図柄のセットと@c
 言うことができます。@c
 以下の構文により、@c
-さまざまな LilyPond @code{feta} 非テキスト フォントを@c
+LilyPond のさまざまな @code{Feta} グリフを@c
 マークアップ モードの中で直接使用することが可能になります:
 
 @lilypond[quote,verbatim,fragment]

--- a/Documentation/ja/notation/vocal.itely
+++ b/Documentation/ja/notation/vocal.itely
@@ -10,7 +10,7 @@
 
 @c \version "2.19.21"
 
-@c Translators: Yoshiki Sawada
+@c Translators: Tomohiro Tatejima, Yoshiki Sawada
 @c Translation status: post-GDP
 
 @node 声楽
@@ -877,6 +877,7 @@
 * 歌詞の水平方向の配置::
 * 歌詞と繰り返し::
 * 歌詞のディヴィージ::
+* 歌詞を共有する多声::
 @end menu
 
 
@@ -1646,6 +1647,95 @@ contraltoWords = \lyricmode { Con -- tral -- to words }
     }
   >>
 }
+@end lilypond
+
+@c 2017-9-22 このノードのみ先に翻訳
+@c 第1章のxrefを正しく動作させるため。
+@node 歌詞を共有する多声
+@unnumberedsubsubsec 歌詞を共有する多声
+@translationof Polyphony with shared lyrics
+
+@cindex NullVoice
+@cindex polyphony, shared lyrics (歌詞を共有する多声)
+@cindex lyrics, shared among voices (歌詞を共有する多声)
+@cindex \partcombine and lyrics (\partcombine と歌詞)
+@funindex \partcombine
+
+2 つのボイスが異なるリズムを持ち、同じ歌詞を共有する場合、@c
+片方のボイスに歌詞を合わせるともう片方には合いません。@c
+下の例では、歌詞が上のボイスにのみ合わせられているため、@c
+2 つ目の延長線が短すぎます:
+
+@lilypond[quote,verbatim]
+soprano = \relative { b'8( c d c) d2 }
+alto = \relative { g'2 b8( a g a) }
+words = \lyricmode { la __ la __ }
+
+\new Staff <<
+  \new Voice = "sopranoVoice" { \voiceOne \soprano }
+  \new Voice { \voiceTwo \alto }
+  \new Lyrics \lyricsto "sopranoVoice" \words
+>>
+@end lilypond
+
+望んでいた結果を得るには、2 つのボイスを適切に合わせた新たな
+@code{NullVoice} コンテキストを作り、歌詞をそれに合わせます。@c
+@code{NullVoice} コンテキストの音符は出力には現れませんが、@c
+歌詞を正しく合わせるのに使うことができます:
+
+@lilypond[quote,verbatim]
+soprano = \relative { b'8( c d c) d2 }
+alto = \relative { g'2 b8( a g a) }
+aligner = \relative { b'8( c d c) b( a g a) }
+words = \lyricmode { la __ la __ }
+
+\new Staff <<
+  \new Voice { \voiceOne \soprano }
+  \new Voice { \voiceTwo \alto }
+  \new NullVoice = "aligner" \aligner
+  \new Lyrics \lyricsto "aligner" \words
+>>
+@end lilypond
+
+この方法は、単体では歌詞をサポートしていない
+@code{\partcombine} 関数にも用いることができます:
+
+@lilypond[quote,verbatim]
+soprano = \relative { b'8( c d c) d2 }
+alto = \relative { g'2 b8( a g a) }
+aligner = \relative { b'8( c d c) b( a g a) }
+words = \lyricmode { la __ la __ }
+
+\new Staff <<
+  \new Voice \partcombine \soprano \alto
+  \new NullVoice = "aligner" \aligner
+  \new Lyrics \lyricsto "aligner" \words
+>>
+@end lilypond
+
+@knownissues
+@code{\addLyrics} 関数は @code{Voice} にのみ動作するため、@c
+@code{NullVoice} と一緒に用いることはできません。
+
+@noindent
+@code{\partcombine} 関数については、@ref{自動パート結合}に説明があります。
+
+最後に、この方法はボイスが異なる譜にある場合にも用いることができ、@c
+2 つよりも多くのボイスにも適用することができます:
+
+@lilypond[quote,verbatim]
+soprano = \relative { b'8( c d c) d2 }
+altoOne = \relative { g'2 b8( a b4) }
+altoTwo = \relative { d'2 g4( fis8 g) }
+aligner = \relative { b'8( c d c) d( d d d) }
+words = \lyricmode { la __ la __ }
+
+\new ChoirStaff \with {\accepts NullVoice } <<
+  \new Staff \soprano
+  \new NullVoice = "aligner" \aligner
+  \new Lyrics \lyricsto "aligner" \words
+  \new Staff \partcombine \altoOne \altoTwo
+>>
 @end lilypond
 
 
@@ -2558,7 +2648,7 @@ LilyPond で台詞を譜刻することはできますが、台詞には音楽�
 @ref{Text},
 @ref{Text markup commands}
 
-LilyPond の拡張:
+拡張:
 @rextend{Markup construction in Scheme}
 
 


### PR DESCRIPTION
http://lilypond.org/doc/v2.19/Documentation/contributor/documentation-translation-details に載っている順でNRのアップデートを進めていきたいと思います。
最終的なコミットの粒度についてですが、大見出し（Musical notation, Specialist notation, ...）で1つといったあたりが無難でしょうか。ご意見お待ちしております。